### PR TITLE
Add ListServices CIP Request

### DIFF
--- a/listservices.go
+++ b/listservices.go
@@ -1,0 +1,68 @@
+package gologix
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+func (client *Client) ListServices() ([]CIPListService, error) {
+	client.Logger.Debug("listing services")
+
+	_, data, err := client.send_recv_data(cipCommandListServices)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := readItems(data)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse items. %w", err)
+	}
+
+	services := make([]CIPListService, len(items))
+	for i, item := range items {
+		err := services[i].ParseFromBytes(item.Data)
+		if err != nil {
+			return nil, fmt.Errorf("problem reading list services response. %w", err)
+		}
+	}
+
+	return services, nil
+}
+
+type CIPServiceTypeCode uint16
+
+const (
+	CIPServiceTypeCode_ListServices CIPServiceTypeCode = 0x0100
+)
+
+type CIPListService struct {
+	EncapProtocolVersion uint16
+	Capabilities         ServiceCapabilityFlags
+	Name                 string
+}
+
+func (s *CIPListService) ParseFromBytes(data []byte) error {
+	buf := bytes.NewBuffer(data)
+
+	err := binary.Read(buf, binary.LittleEndian, &s.EncapProtocolVersion)
+	if err != nil {
+		return fmt.Errorf("problem reading list services response. field EncapProtocolVersion %w", err)
+	}
+
+	err = binary.Read(buf, binary.LittleEndian, &s.Capabilities)
+	if err != nil {
+		return fmt.Errorf("problem reading list services response. field CapFlags %w", err)
+	}
+
+	// The name field is a 16 byte null terminated string
+	name := make([]byte, 16)
+	err = binary.Read(buf, binary.LittleEndian, &name)
+	if err != nil {
+		return fmt.Errorf("problem reading list services response. field Name %w", err)
+	}
+	// Remove any trailing NULL characters from the name
+	s.Name = string(bytes.TrimRight(name, "\x00"))
+
+	return nil
+}

--- a/listservices.go
+++ b/listservices.go
@@ -30,12 +30,6 @@ func (client *Client) ListServices() ([]CIPListService, error) {
 	return services, nil
 }
 
-type CIPServiceTypeCode uint16
-
-const (
-	CIPServiceTypeCode_ListServices CIPServiceTypeCode = 0x0100
-)
-
 type CIPListService struct {
 	EncapProtocolVersion uint16
 	Capabilities         ServiceCapabilityFlags

--- a/listservices_test.go
+++ b/listservices_test.go
@@ -1,0 +1,25 @@
+package gologix
+
+import (
+	"testing"
+)
+
+func TestParseListServicesResponse(t *testing.T) {
+	itemBytes := []byte{1, 0, 32, 1, 67, 111, 109, 109, 117, 110, 105, 99, 97, 116, 105, 111, 110, 115, 0, 0}
+
+	response := CIPListService{}
+	err := response.ParseFromBytes(itemBytes)
+	if err != nil {
+		t.Fatalf("error parsing list services response: %v", err)
+	}
+
+	expected := CIPListService{
+		EncapProtocolVersion: 1,
+		Capabilities:         ServiceCapabilityFlag_CipEncapsulation | ServiceCapabilityFlag_SupportsClass1UDP,
+		Name:                 "Communications",
+	}
+
+	if response != expected {
+		t.Fatalf("expected %v, got %v", expected, response)
+	}
+}

--- a/tests/list_services_test.go
+++ b/tests/list_services_test.go
@@ -1,0 +1,49 @@
+package gologix_tests
+
+import (
+	"testing"
+
+	"github.com/danomagnum/gologix"
+)
+
+func TestListServices(t *testing.T) {
+	// This test is a placeholder for the actual implementation
+	tcs := getTestConfig()
+	for _, tc := range tcs.ListServices {
+		t.Run(tc.Address, func(t *testing.T) {
+			client := gologix.NewClient(tc.Address)
+			err := client.Connect()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer func() {
+				err := client.Disconnect()
+				if err != nil {
+					t.Errorf("problem disconnecting. %v", err)
+				}
+			}()
+
+			services, err := client.ListServices()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if services == nil {
+				t.Error("services is nil")
+				return
+			}
+
+			for i, service := range services {
+				if service.Name != tc.Services[i].Name {
+					t.Errorf("Name mismatch on entry %d. Have %s. Want %s.", i, service.Name, tc.Services[i].Name)
+				}
+
+				if service.Capabilities != gologix.ServiceCapabilityFlags(tc.Services[i].Capabilities) {
+					t.Errorf("Capabilities mismatch on entry %d. Have %d. Want %d.", i, service.Capabilities, tc.Services[i].Capabilities)
+				}
+			}
+		})
+	}
+}

--- a/tests/test_config template.json
+++ b/tests/test_config template.json
@@ -22,5 +22,17 @@
       "SerialNumber": 1615551361,
       "ProductName": "1769-L35E/B LOGIX5335E"
     }
+  ],
+  "README_4": "ListServices is used to identify the services on the devices.",
+  "ListServices": [
+    {
+      "Device_Address": "192.168.2.241",
+      "Services": [
+        {
+          "Name": "Communications",
+          "Capabilities": 288
+        }
+      ]
+    }
   ]
 }

--- a/tests/test_setup.go
+++ b/tests/test_setup.go
@@ -15,6 +15,7 @@ type TestConfig struct {
 		SerialNumber         uint32 `json:"SerialNumber"`
 		ProductName          string `json:"ProductName"`
 	} `json:"PLC_List"`
+
 	ListIdentify []struct {
 		Address              string `json:"Device_Address"`
 		Vendor               uint16 `json:"Vendor"`
@@ -27,6 +28,14 @@ type TestConfig struct {
 		ProductName          string `json:"ProductName"`
 		State                uint8  `json:"State"`
 	} `json:"ListIdentify"`
+
+	ListServices []struct {
+		Address  string `json:"Device_Address"`
+		Services []struct {
+			Name         string `json:"Name"`
+			Capabilities uint16 `json:"Capabilities"`
+		} `json:"Services"`
+	} `json:"ListServices"`
 }
 
 func getTestConfig() TestConfig {


### PR DESCRIPTION
This PR adds support for the `ListServices` CIP command.

I tested this with both a Omron NX102 PLC and a IQ Sensor Net System, but unfortunately both only list "Communications" as the supported services, so I don't have any better examples with more services.

The Integration tests here are probably going to have conflicts with the ones in https://github.com/danomagnum/gologix/pull/29#issuecomment-2735174614 but let me know when those are merged, and I'll rebase this.