### PR TITLE
L5x comment parsing

### DIFF
--- a/examples/ReadTagsFromL5X/main.go
+++ b/examples/ReadTagsFromL5X/main.go
@@ -32,10 +32,29 @@ func main() {
 		log.Fatal(err)
 	}
 
-	result, err := l5x.LoadTags(l5xData)
+	tags, err := l5x.LoadTags(l5xData)
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Print(result)
+	for k, v := range tags {
+		log.Printf("%s: %v\n", k, v)
+	}
+
+	tagComments, err := l5x.LoadTagComments(l5xData)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for k, v := range tagComments {
+		log.Printf("%s: %v\n", k, v)
+	}
+
+	rungComments, err := l5x.LoadRungComments(l5xData)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for k, v := range rungComments {
+		log.Printf("%s: %v\n", k, v)
+	}
 
 }

--- a/examples/ReadTagsFromL5X/main.go
+++ b/examples/ReadTagsFromL5X/main.go
@@ -18,6 +18,8 @@ import (
 func main() {
 	var l5xData l5x.RSLogix5000Content
 
+	log.SetOutput(os.Stdout)
+
 	f, err := os.Open("gologix_tests_Program.L5X")
 	if err != nil {
 		log.Fatal(err)

--- a/l5x/load_tags.go
+++ b/l5x/load_tags.go
@@ -179,6 +179,17 @@ func LoadTagComments(l5xData RSLogix5000Content) (map[string]any, error) {
 func LoadRungComments(l5xData RSLogix5000Content) (map[string]string, error) {
 	comments := make(map[string]string)
 
+	taskLookup := make(map[string]string)
+	tasks := l5xData.Controller.Tasks.Task
+	for _, task := range tasks {
+		if task.ScheduledPrograms == nil {
+			continue
+		}
+		for _, program := range task.ScheduledPrograms.ScheduledProgram {
+			taskLookup[program.NameAttr] = task.NameAttr
+		}
+	}
+
 	for _, program := range l5xData.Controller.Programs.Program {
 		for _, routine := range program.Routines.Routine {
 			for _, rungContent := range routine.RLLContent {
@@ -188,7 +199,8 @@ func LoadRungComments(l5xData RSLogix5000Content) (map[string]string, error) {
 						if c == "" {
 							continue
 						}
-						location := fmt.Sprintf("program:%s.rung:%s", program.NameAttr, rung.NumberAttr)
+						task := taskLookup[program.NameAttr]
+						location := fmt.Sprintf("%s/%s/%s[%s]", task, program.NameAttr, routine.NameAttr, rung.NumberAttr)
 						comments[location] = c
 					}
 				}

--- a/l5x/load_tags.go
+++ b/l5x/load_tags.go
@@ -101,6 +101,51 @@ func LoadTagComments(l5xData RSLogix5000Content) (map[string]any, error) {
 	var err error
 	tags := make(map[string]any)
 
+	for _, module := range l5xData.Controller.Modules.Module {
+		if module.Communications == nil {
+			continue
+		}
+		if module.Communications.Connections == nil {
+			continue
+		}
+		if module.Communications.Connections.Connection == nil {
+			continue
+		}
+		for _, connection := range module.Communications.Connections.Connection {
+			in := connection.InputTag
+			if in != nil {
+				if in.Comments != nil {
+					for _, commentGroup := range in.Comments {
+						for _, comment := range commentGroup.Comment {
+							name := fmt.Sprintf("%s:I%s", module.NameAttr, comment.OperandAttr)
+							c := comment.CData()
+							if c == "" {
+								continue
+							}
+							tags[name] = c
+						}
+					}
+				}
+			}
+			out := connection.OutputTag
+			if out != nil {
+				if out.Comments != nil {
+					for _, commentGroup := range out.Comments {
+						for _, comment := range commentGroup.Comment {
+							name := fmt.Sprintf("%s:O%s", module.NameAttr, comment.OperandAttr)
+							c := comment.CData()
+							if c == "" {
+								continue
+							}
+							tags[name] = c
+						}
+					}
+				}
+			}
+
+		}
+	}
+
 	for _, tag := range l5xData.Controller.Tags.Tag {
 		if tag.Data != nil {
 			if len(tag.Description) > 0 {

--- a/l5x/schema.go
+++ b/l5x/schema.go
@@ -152,6 +152,11 @@ type DescriptionType struct {
 	UseAttr              string                          `xml:"Use,attr,omitempty"`
 	CustomProperties     *CustomPropertiesCollectionType `xml:"CustomProperties"`
 	LocalizedDescription []*DescriptionTextType          `xml:"LocalizedDescription"`
+	InnerValue           []byte                          `xml:",innerxml"`
+}
+
+func (d DescriptionType) CData() string {
+	return ParseCData(d.InnerValue)
 }
 
 // DescriptionTextType ...
@@ -1096,6 +1101,15 @@ type TagType struct {
 	Navigations        []*NavigationCollectionType             `xml:"Navigations"`
 	Data               []*DataWideType                         `xml:"Data"`
 	ForceData          []*ForceDataWideType                    `xml:"ForceData"`
+}
+
+func (t *TagType) Descriptions() string {
+	comment := ""
+	for d := range t.Description {
+		comment = comment + t.Description[d].CData()
+	}
+
+	return comment
 }
 
 // CommentCollectionType ...
@@ -3846,6 +3860,11 @@ type CommentWideType struct {
 	DecoratedDataElements []*DecoratedDataElements
 	Value                 []string                  `xml:"Value"`
 	LocalizedComment      []*CommentAdaptorTextType `xml:"LocalizedComment"`
+	InnerValue            []byte                    `xml:",innerxml"`
+}
+
+func (d CommentWideType) CData() string {
+	return ParseCData(d.InnerValue)
 }
 
 // LocalizedCommentWideType ...


### PR DESCRIPTION
This pull request introduces several significant changes to the `examples/ReadTagsFromL5X/main.go` and `l5x` package to enhance functionality and improve code readability. The most important changes include adding new functions to load tag comments and rung comments, updating the main function to utilize these new functions, and enhancing the `DescriptionType` and `CommentWideType` structures to parse and handle inner XML values.

Enhancements to functionality:

* [`examples/ReadTagsFromL5X/main.go`](diffhunk://#diff-92a07c01ab1c578bbfbd2586aa4ec75eb3b5e03e48f8b8bb5dc1f879695932acL35-R60): Updated the main function to load and print tag comments and rung comments using the new `LoadTagComments` and `LoadRungComments` functions.
* [`l5x/load_tags.go`](diffhunk://#diff-2ce7a9dacf36bc2f7b25c56a678111e5d1b5e3e394e9198d7179291b8e9b503bR98-R211): Added `LoadTagComments` and `LoadRungComments` functions to extract and return comments from tags and rungs respectively.

Improvements to data handling:

* [`l5x/schema.go`](diffhunk://#diff-bd73c0cbf521fe12c4caccfec0192a8e900eac1b41c7567b22b9de80cbdfd914R155-R159): Enhanced `DescriptionType` and `CommentWideType` structures to include `InnerValue` for parsing inner XML values and added `CData` methods to extract CDATA content. [[1]](diffhunk://#diff-bd73c0cbf521fe12c4caccfec0192a8e900eac1b41c7567b22b9de80cbdfd914R155-R159) [[2]](diffhunk://#diff-bd73c0cbf521fe12c4caccfec0192a8e900eac1b41c7567b22b9de80cbdfd914R3863-R3867)
* [`l5x/schema.go`](diffhunk://#diff-bd73c0cbf521fe12c4caccfec0192a8e900eac1b41c7567b22b9de80cbdfd914R1106-R1114): Added a `Descriptions` method to the `TagType` structure to concatenate and return descriptions.

Logging improvements:

* [`examples/ReadTagsFromL5X/main.go`](diffhunk://#diff-92a07c01ab1c578bbfbd2586aa4ec75eb3b5e03e48f8b8bb5dc1f879695932acR21-R22): Set the log output to `os.Stdout` for better visibility of log messages.