### PR TITLE
Feature: Bool Array Reads

### DIFF
--- a/tests/read_test.go
+++ b/tests/read_test.go
@@ -442,3 +442,95 @@ func TestReadParallel(t *testing.T) {
 		})
 	}
 }
+
+func TestReadBoolArray64(t *testing.T) {
+	tcs := getTestConfig()
+	for _, tc := range tcs.TagReadWriteTests {
+		t.Run(tc.PlcAddress, func(t *testing.T) {
+			client := gologix.NewClient(tc.PlcAddress)
+			err := client.Connect()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer func() {
+				err := client.Disconnect()
+				if err != nil {
+					t.Errorf("problem disconnecting. %v", err)
+				}
+			}()
+
+			tag := "Program:gologix_tests.boolarray64"
+			have := make([]bool, 64)
+			want := []bool{
+				true, false, false, false, false, false, false, false,
+				true, true, false, false, false, false, false, false,
+				true, true, true, false, false, false, false, false,
+				true, true, true, true, false, false, false, false,
+				true, true, true, true, true, false, false, false,
+				true, true, true, true, true, true, false, false,
+				true, true, true, true, true, true, true, false,
+				true, true, true, true, true, true, true, true,
+			}
+
+			err = client.Read(tag, have)
+			if err != nil {
+				t.Errorf("error reading array: %v", err)
+			}
+
+			if len(have) != len(want) {
+				t.Errorf("didn't get the right number of elements. got %v wanted %v", len(have), len(want))
+			}
+
+			for i := range want {
+				if have[i] != want[i] {
+					t.Errorf("index %d wanted %v got %v", i+1, want[i], have[i])
+				}
+			}
+		})
+	}
+}
+
+func TestReadBoolArray32(t *testing.T) {
+	tcs := getTestConfig()
+	for _, tc := range tcs.TagReadWriteTests {
+		t.Run(tc.PlcAddress, func(t *testing.T) {
+			client := gologix.NewClient(tc.PlcAddress)
+			err := client.Connect()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer func() {
+				err := client.Disconnect()
+				if err != nil {
+					t.Errorf("problem disconnecting. %v", err)
+				}
+			}()
+
+			tag := "Program:gologix_tests.boolarray"
+			have := make([]bool, 32)
+			want := []bool{
+				true, false, false, false, false, false, false, false,
+				true, true, false, false, false, false, false, false,
+				true, true, true, false, false, false, false, false,
+				true, true, true, true, false, false, false, false,
+			}
+
+			err = client.Read(tag, have)
+			if err != nil {
+				t.Errorf("error reading array: %v", err)
+			}
+
+			if len(have) != len(want) {
+				t.Errorf("didn't get the right number of elements. got %v wanted %v", len(have), len(want))
+			}
+
+			for i := range want {
+				if have[i] != want[i] {
+					t.Errorf("index %d wanted %v got %v", i+1, want[i], have[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request enhances the handling of `[]bool` slices in the `Read` method of the `Client` class and introduces new test cases to validate the changes. The most significant changes include adding support for boolean slices in multiples of length 32, improving error handling, and ensuring proper bit-level operations.

### Enhancements to `Read` method:

* Updated the `Read` method in `read.go` to handle `[]bool` slices of lengths that are multiples of 32. Added a special case for slices of length 32 to read them as an atomic `uint32` and perform bit-level unpacking.
* Added validation to ensure the length of the `[]bool` slice is a multiple of 32, returning an error otherwise.

### New test cases:

* Introduced `TestReadBoolArray64` in `read_test.go` to verify the correct reading of a `[]bool` slice with 64 elements, including expected bit-level values.
* Added `TestReadBoolArray32` in `read_test.go` to validate the special case for reading a `[]bool` slice with 32 elements, ensuring proper unpacking and value checks.Functionality to write bool arrays is still not implemented.