### PR TITLE
Fix bug that could end in an infinite loop.  Better cache member and …

### DIFF
--- a/client.go
+++ b/client.go
@@ -66,9 +66,10 @@ type Client struct {
 	// it maps tag names to a struct which has, among other things, the instance ID and class
 	// which can be used to read the tag more efficiently than sending the ascii tag name to the
 	// controller.  If you don't want to use this, set SocketTimeout to 0 and never call ListAllTags
-	KnownTags     map[string]KnownTag
-	KnownTypes    map[string]UDTDescriptor
-	KnownPrograms map[string]*KnownProgram
+	KnownTags      map[string]KnownTag
+	KnownTypes     map[string]UDTDescriptor
+	KnownTypesByID map[uint32]UDTDescriptor
+	KnownPrograms  map[string]*KnownProgram
 
 	// used for optimization.  v20 and before vs v21 and after have different
 	// tag reading functionality.
@@ -129,6 +130,7 @@ func NewClient(ip string) *Client {
 		SocketTimeout:      socketTimeoutDefault,
 		KnownTags:          make(map[string]KnownTag),
 		KnownTypes:         make(map[string]UDTDescriptor),
+		KnownTypesByID:     make(map[uint32]UDTDescriptor),
 		ioi_cache:          make(map[string]*tagIOI),
 		Logger:             NewLogger(),
 	}

--- a/listalltags.go
+++ b/listalltags.go
@@ -160,6 +160,8 @@ func (client *Client) ListAllTags(start_instance uint32) error {
 		if err != nil {
 			return fmt.Errorf("problem reading tag header. %w", err)
 		}
+		start_instance = tag_hdr.InstanceID
+
 		tag_name := make([]byte, tag_hdr.NameLength)
 		err = binary.Read(data2, binary.LittleEndian, &tag_name)
 		if err != nil {
@@ -232,8 +234,6 @@ func (client *Client) ListAllTags(start_instance uint32) error {
 		}
 
 		client.KnownTags[strings.ToLower(string(tag_name))] = kt
-
-		start_instance = tag_hdr.InstanceID
 
 	}
 


### PR DESCRIPTION
This pull request introduces enhancements to the `Client` struct and related methods to improve the handling of user-defined types (UDTs) and optimize tag and member processing. The key changes include adding a new map to track UDT descriptors by ID, optimizing `ListMembers` with caching, and introducing a helper method for extracting template IDs.

### Enhancements to `Client` struct:
* Added a new field `KnownTypesByID` to the `Client` struct for caching UDT descriptors by their instance IDs. This improves lookup efficiency for UDTs. (`client.go`, [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR71) [[2]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfR133)

### Improvements to `ListMembers` method:
* Implemented caching in `ListMembers` to return pre-existing UDT descriptors from `KnownTypesByID` if available, reducing redundant computations. (`listmembers.go`, [listmembers.goR144-R148](diffhunk://#diff-badf6d63dd14fb566d07483c4b2d2036f8252de27475d0f16fef159bf334e69bR144-R148))
* Updated `ListMembers` to recursively fetch and assign nested UDTs to their parent members, enhancing support for complex UDT structures. (`listmembers.go`, [listmembers.goR247-R259](diffhunk://#diff-badf6d63dd14fb566d07483c4b2d2036f8252de27475d0f16fef159bf334e69bR247-R259))
* Cached the resulting UDT descriptor in `KnownTypesByID` after processing, ensuring future lookups are faster. (`listmembers.go`, [listmembers.goR247-R259](diffhunk://#diff-badf6d63dd14fb566d07483c4b2d2036f8252de27475d0f16fef159bf334e69bR247-R259))

### New helper method for UDTs:
* Added a `Template_ID` method to `UDTMemberDescriptor` to extract the template ID from a member's type, adhering to the CIP specification. This simplifies identifying UDT templates. (`listmembers.go`, [listmembers.goR289-R304](diffhunk://#diff-badf6d63dd14fb566d07483c4b2d2036f8252de27475d0f16fef159bf334e69bR289-R304))

### Adjustments to `ListAllTags` method:
* Moved the reassignment of `start_instance` to immediately follow the tag header read, ensuring the variable is updated at the correct point in the process. (`listalltags.go`, [[1]](diffhunk://#diff-887ac2274ee9881752c905743600d4a1e3e7e27940060eddf302e642ccc37d7bR163-R164) [[2]](diffhunk://#diff-887ac2274ee9881752c905743600d4a1e3e7e27940060eddf302e642ccc37d7bL236-L237)…lookup members recursively.