### PR TITLE
fix readList to support multi-packet messages

### DIFF
--- a/tests/read_multi_test.go
+++ b/tests/read_multi_test.go
@@ -215,3 +215,60 @@ func TestReadMultiWithGaps(t *testing.T) {
 		})
 	}
 }
+
+func TestReadMultiWithGaps2(t *testing.T) {
+	tcs := getTestConfig()
+	for _, tc := range tcs.TagReadWriteTests {
+		t.Run(tc.PlcAddress, func(t *testing.T) {
+			client := gologix.NewClient(tc.PlcAddress)
+			err := client.Connect()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer func() {
+				err := client.Disconnect()
+				if err != nil {
+					t.Errorf("problem disconnecting. %v", err)
+				}
+			}()
+
+			type multiread struct {
+				TestInt  int16 `gologix:"TestInt"`
+				NotATag  int32
+				TestDint int32   `gologix:"TestDint"`
+				TestArr  []int32 `gologix:"TestDintArr"`
+			}
+			var mr multiread
+			mr.TestArr = make([]int32, 5)
+
+			// call the read multi function with the structure passed in as a pointer.
+			err = client.ReadMulti(&mr)
+			if err != nil {
+				log.Printf("error reading testint. %v", err)
+			}
+
+			if mr.TestInt != 999 {
+				t.Errorf("TestInt expected 999 but got %d", mr.TestInt)
+			}
+			if mr.NotATag != 0 {
+				t.Errorf("NotATag expected 0 but got %d", mr.NotATag)
+			}
+			if mr.TestDint != 36 {
+				t.Errorf("TestDint expected 36 but got %d", mr.TestDint)
+			}
+			if mr.TestArr[0] != 4351 {
+				t.Errorf("TestArr[0] expected 4353 but got %d", mr.TestArr[0])
+			}
+			if mr.TestArr[1] != 4352 {
+				t.Errorf("TestArr[1] expected 4354 but got %d", mr.TestArr[1])
+			}
+			if mr.TestArr[2] != 4353 {
+				t.Errorf("TestArr[2] expected 4355 but got %d", mr.TestArr[2])
+			}
+			if mr.TestArr[3] != 4354 {
+				t.Errorf("TestArr[3] expected 4356 but got %d", mr.TestArr[3])
+			}
+		})
+	}
+}

--- a/tests/read_test.go
+++ b/tests/read_test.go
@@ -228,6 +228,9 @@ func testReadNew[T gologix.GoLogixTypes](t *testing.T, client *gologix.Client, t
 }
 
 func TestReadMulti(t *testing.T) {
+	// this assortment of reads is just longer than a small forward open so
+	// it will test that the library can handle multiple reads in a single forward open on some PLCs and
+	// a single forward open on others.
 	type test_str struct {
 		TestSint          int8    `gologix:"program:gologix_tests.readsint"`
 		TestInt           int16   `gologix:"program:gologix_tests.readint"`


### PR DESCRIPTION
This pull request introduces enhancements to the `Client` class in `read.go` to improve handling of multi-tag reads, adds logic for splitting large read requests into smaller ones, and expands test coverage to validate these changes. The most significant updates include refactoring the `ReadMulti` method, implementing a recursive strategy in `readList` to handle large requests, and adding new test cases for multi-tag reads.

### Refactoring and Feature Enhancements:

* **Refactored `ReadMulti` Method**: Simplified tag handling by introducing a `tagDesc` structure. This encapsulates tag metadata (`TagName`, `TagType`, `Elements`, and `Struct`) for better organization and readability. Also added a check to skip empty tags. (`read.go`, [read.goR598-R620](diffhunk://#diff-2afeb2e02182ad5bb61e988b290013cdc0e5dd12981568a89dec415caafab361R598-R620))
* **Recursive Handling of Large Requests in `readList`**: Added logic to split large read requests into smaller chunks based on `ConnectionSize`. The method now recursively processes the tags, ensuring compatibility with PLCs that have size limitations. (`read.go`, [read.goR702-R720](diffhunk://#diff-2afeb2e02182ad5bb61e988b290013cdc0e5dd12981568a89dec415caafab361R702-R720))

### Test Coverage Improvements:

* **Added `TestReadMultiWithGaps2`**: Introduced a new test case to validate multi-tag reads with gaps in tag definitions. This ensures the `ReadMulti` method correctly handles structures with tags and non-tag fields. (`tests/read_multi_test.go`, [tests/read_multi_test.goR218-R274](diffhunk://#diff-178aa620aa56f5e086d66d6d50861d7af0687b51978594da7cbac749a0acbdc5R218-R274))
* **Extended `TestReadMulti` Description**: Updated comments to clarify the purpose of the test, which checks handling of multiple reads in a single forward open or across multiple forward opens depending on PLC behavior. (`tests/read_test.go`, [tests/read_test.goR231-R233](diffhunk://#diff-729313d28349ab5a540e0d60adee35eedd02db2dca4f3ba6c90ba338b485ba32R231-R233))