### PR TITLE
added []int8 to cip to go function

### DIFF
--- a/types.go
+++ b/types.go
@@ -47,6 +47,8 @@ func GoVarToCIPType(T any) (CIPType, int) {
 		return CIPTypeSTRING, 1
 	case []byte:
 		return CIPTypeBYTE, len(x)
+	case []int8:
+		return CIPTypeSINT, len(x)
 	case []uint16:
 		return CIPTypeUINT, len(x)
 	case []int16:


### PR DESCRIPTION
[]int8 was missing from the govartociptype function.