### PR TITLE
Add CIP DataTable buffer support for grouped tag reads

### DIFF
--- a/cip_definitions.go
+++ b/cip_definitions.go
@@ -363,6 +363,7 @@ const (
 	CipObject_DPIDevice                    CIPClass = 0x92
 	CipObject_DPIParams                    CIPClass = 0x93
 	CipObject_DPIFault                     CIPClass = 0x97
+	CipObject_DataTable                    CIPClass = 0xB2 // DataTable buffer for grouped tag reads
 )
 
 // from https://rockwellautomation.custhelp.com/ci/okcsFattach/get/114390_5

--- a/datatable.go
+++ b/datatable.go
@@ -1,0 +1,694 @@
+package gologix
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DataTableBufferTag tracks a single tag that has been added to a datatable buffer.
+// The index is 1-based, sequential in the order tags were added across all AddTag/AddTags calls.
+type DataTableBufferTag struct {
+	Name         string  // symbolic tag name (or "" for instance-addressed tags)
+	CIPType      CIPType // the CIP data type of the tag
+	DataTypeSize uint16  // raw byte count used by the datatable protocol
+	index        uint16  // 1-based sequential position in the buffer
+	ioi          []byte  // raw IOI EPath bytes
+	batchID      uint16  // 0x4E response value — groups tags for 0x4C read parsing
+}
+
+// Index returns the 1-based PLC-assigned index for this tag in the buffer.
+func (t DataTableBufferTag) Index() uint16 { return t.index }
+
+// DataTableBuffer represents a CIP class 0xB2 datatable buffer instance on the PLC.
+// It tracks the buffer's lifecycle state, the instance ID returned by Create,
+// and the list of tags that have been added along with their type sizes.
+//
+// The buffer is read-only from the client side. Tags are associated with the buffer
+// via AddTag/AddTags/AddTagGroup, and all values are read at once via ReadAll or
+// ReadAllTyped. To write tag values, use the standard Client.Write() method directly.
+//
+// DataTableBuffer is NOT safe for concurrent use from multiple goroutines.
+type DataTableBuffer struct {
+	client     *Client
+	instanceID uint16               // assigned by PLC during Create; use InstanceID() getter
+	tags       []DataTableBufferTag // tags added to the buffer, in order; use Tags() getter
+	created    bool                 // true after successful Create
+	// expansions tracks multi-element TagDef expansions from AddTagGroup.
+	// Key: the base resolved tag name (e.g. "EXAMPLE[1,0]")
+	// Value: the expanded individual tag names (e.g. ["EXAMPLE[1,0]", ..., "EXAMPLE[1,4]"])
+	expansions map[string][]string
+}
+
+// InstanceID returns the PLC-assigned instance ID for this datatable buffer.
+func (buf *DataTableBuffer) InstanceID() uint16 { return buf.instanceID }
+
+// Tags returns a copy of the tags added to this buffer.
+func (buf *DataTableBuffer) Tags() []DataTableBufferTag {
+	out := make([]DataTableBufferTag, len(buf.tags))
+	copy(out, buf.tags)
+	return out
+}
+
+// dataTablePath builds the 6-byte CIP path for class 0xB2 with a 16-bit instance ID.
+// Forces 16-bit instance encoding (0x25) to match the reverse-engineered protocol.
+func dataTablePath(instanceID uint16) []byte {
+	path := []byte{0x20, 0xB2, 0x25, 0x00, 0x00, 0x00}
+	binary.LittleEndian.PutUint16(path[4:], instanceID)
+	return path
+}
+
+// dataTableTypeSize maps a CIPType to the raw byte count used by the datatable
+// protocol's dataTypeSize field (LE16). This is a byte count, not a CIP type code.
+//
+// For most atomic types this matches CIPType.Size(). The exception is CIPTypeSTRING
+// (gologix internal 0xFF) which returns Size()=1 but the datatable protocol expects
+// 88 bytes (4-byte .LEN + 82-byte .DATA + 2 pad for standard AB STRING).
+func dataTableTypeSize(t CIPType) (uint16, error) {
+	switch t {
+	case CIPTypeSTRING:
+		return 88, nil
+	case CIPTypeStruct:
+		return 88, nil
+	default:
+		s := t.Size()
+		if s == 0 {
+			return 0, fmt.Errorf("unsupported CIP type %v for datatable buffer", t)
+		}
+		return uint16(s), nil
+	}
+}
+
+// resolveTypeSize determines the datatable slot size for a tag. For STRING and
+// Struct types it checks client.KnownTags for the tag's UDT descriptor, which
+// carries the actual template data size (msgGetTemplateAttrListResponse.SizeBytes,
+// attribute 5 of the CIP template object). This handles custom string types like
+// STRING20 or STRING40 whose slot sizes differ from the standard 88-byte AB STRING.
+//
+// Falls back to dataTableTypeSize() if the tag is not in KnownTags or has no UDT.
+func (buf *DataTableBuffer) resolveTypeSize(tagName string, cipType CIPType) (uint16, error) {
+	if cipType == CIPTypeSTRING || cipType == CIPTypeStruct {
+		kt, ok := buf.client.KnownTags[strings.ToLower(tagName)]
+		if ok && kt.UDT != nil && kt.UDT.Info.SizeBytes > 0 {
+			return uint16(kt.UDT.Info.SizeBytes), nil
+		}
+	}
+	return dataTableTypeSize(cipType)
+}
+
+// decodeDataTableValue converts raw bytes from a datatable read response into
+// the appropriate Go type based on the CIP type.
+//
+// For STRING types (88 bytes), the format is: uint32 length + char data + padding.
+// For all other atomic types, this delegates to the existing readValue() function.
+func decodeDataTableValue(cipType CIPType, raw []byte) (any, error) {
+	if cipType == CIPTypeSTRING || cipType == CIPTypeStruct {
+		if len(raw) < 4 {
+			return nil, fmt.Errorf("STRING data too short: got %d bytes, need at least 4", len(raw))
+		}
+		strLen := binary.LittleEndian.Uint32(raw[0:4])
+		if strLen > uint32(len(raw)-4) {
+			strLen = uint32(len(raw) - 4)
+		}
+		if strLen > 82 {
+			strLen = 82
+		}
+		return string(raw[4 : 4+strLen]), nil
+	}
+	r := bytes.NewReader(raw)
+	return readValue(cipType, r)
+}
+
+// ---------------------------------------------------------------------------
+// Low-level Client methods — one per CIP service
+// ---------------------------------------------------------------------------
+
+// CreateDataTableBuffer sends a CIP Create (0x08) service to class 0xB2 instance 0x0000,
+// requesting the PLC to allocate a new datatable buffer.
+//
+// The request data is hardcoded to 01 00 03 00 03 00.
+// Returns the instance ID assigned by the PLC.
+func (client *Client) CreateDataTableBuffer() (uint16, error) {
+	err := client.checkConnection()
+	if err != nil {
+		return 0, fmt.Errorf("could not create datatable buffer: %w", err)
+	}
+
+	path := dataTablePath(0x0000)
+	data := []byte{0x01, 0x00, 0x03, 0x00, 0x03, 0x00}
+
+	resp, err := client.GenericCIPMessage(CIPService_Create, path, data)
+	if err != nil {
+		return 0, fmt.Errorf("datatable buffer create failed: %w", err)
+	}
+
+	instanceID, err := resp.Uint16()
+	if err != nil {
+		return 0, fmt.Errorf("could not read instance ID from create response: %w", err)
+	}
+
+	return instanceID, nil
+}
+
+// DeleteDataTableBuffer sends a CIP Delete (0x09) service to class 0xB2 with
+// the specified instance ID, freeing the datatable buffer on the PLC.
+func (client *Client) DeleteDataTableBuffer(instanceID uint16) error {
+	err := client.checkConnection()
+	if err != nil {
+		return fmt.Errorf("could not delete datatable buffer: %w", err)
+	}
+
+	path := dataTablePath(instanceID)
+
+	_, err = client.GenericCIPMessage(CIPService_Delete, path, []byte{})
+	if err != nil {
+		return fmt.Errorf("datatable buffer delete failed: %w", err)
+	}
+	return nil
+}
+
+// addTagEntry describes one tag to add in a multi-tag 0x4E call.
+type addTagEntry struct {
+	dataTypeSize uint16
+	ioi          []byte
+}
+
+// DataTableAddTags sends a CIP service 0x4E to the specified datatable buffer instance,
+// adding one or more tags in a single call. Each tag carries its own dataTypeSize and
+// IOI EPath — mixed type sizes are supported.
+//
+// Wire format (validated against pcap):
+//
+//	[02 00 01 01]         hardcoded header
+//	[1 byte: tagCount]    number of tags in this call
+//	Repeated tagCount times:
+//	  [2 bytes LE: dataTypeSize]  this tag's slot size in bytes
+//	  [1 byte: ioiLenWords]       this tag's IOI length in 16-bit words
+//	  [N bytes: IOI EPath]        this tag's path bytes
+//
+// The response contains a single uint16: a batch/entry index that increments
+// per 0x4E call (1 for the first call, 2 for the second, etc.). This value
+// is used as a group marker in the 0x4C read response.
+func (client *Client) DataTableAddTags(instanceID uint16, entries []addTagEntry) (uint16, error) {
+	err := client.checkConnection()
+	if err != nil {
+		return 0, fmt.Errorf("could not add tag to datatable buffer: %w", err)
+	}
+
+	path := dataTablePath(instanceID)
+
+	// Estimate capacity: 5 header + per-tag (2 typeSize + 1 ioiLen + IOI bytes)
+	capacity := 5
+	for _, e := range entries {
+		capacity += 3 + len(e.ioi)
+	}
+	msgData := make([]byte, 0, capacity)
+
+	// Header: 02 00 01 01
+	msgData = append(msgData, 0x02, 0x00, 0x01, 0x01)
+	// Tag count
+	msgData = append(msgData, byte(len(entries)))
+
+	for _, e := range entries {
+		// Per-tag: dataTypeSize LE16
+		sizeBytes := make([]byte, 2)
+		binary.LittleEndian.PutUint16(sizeBytes, e.dataTypeSize)
+		msgData = append(msgData, sizeBytes...)
+		// Per-tag: IOI length in 16-bit words
+		msgData = append(msgData, byte(len(e.ioi)/2))
+		// Per-tag: IOI EPath bytes
+		msgData = append(msgData, e.ioi...)
+	}
+
+	// Service 0x4E — Add Tag when targeting class 0xB2 buffer instance.
+	resp, err := client.GenericCIPMessage(CIPService(0x4E), path, msgData)
+	if err != nil {
+		return 0, fmt.Errorf("datatable add tag failed: %w", err)
+	}
+
+	batchIndex, err := resp.Uint16()
+	if err != nil {
+		return 0, fmt.Errorf("could not read batch index from add tag response: %w", err)
+	}
+	return batchIndex, nil
+}
+
+// DataTableAddTag sends a CIP service 0x4E to add a single tag to the datatable buffer.
+// This is a convenience wrapper around DataTableAddTags for single-tag adds.
+func (client *Client) DataTableAddTag(instanceID uint16, dataTypeSize uint16, tagIOIs []byte) (uint16, error) {
+	return client.DataTableAddTags(instanceID, []addTagEntry{{dataTypeSize, tagIOIs}})
+}
+
+// DataTableReadBuffer sends a CIP Read (0x4C) service to the specified datatable
+// buffer instance, reading all tag values in a single response.
+//
+// The returned CIPItem contains: [tagCount LE16] [concatenated tag values...].
+// The caller must know the order and sizes of tags to parse the response.
+func (client *Client) DataTableReadBuffer(instanceID uint16) (*CIPItem, error) {
+	err := client.checkConnection()
+	if err != nil {
+		return nil, fmt.Errorf("could not read datatable buffer: %w", err)
+	}
+
+	path := dataTablePath(instanceID)
+
+	resp, err := client.GenericCIPMessage(CIPService_Read, path, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("datatable buffer read failed: %w", err)
+	}
+	return resp, nil
+}
+
+// DataTableRemoveTag sends a CIP service 0x4F to remove a tag from the datatable
+// buffer by its 1-based index.
+func (client *Client) DataTableRemoveTag(instanceID uint16, tagIndex uint16) error {
+	err := client.checkConnection()
+	if err != nil {
+		return fmt.Errorf("could not remove tag from datatable buffer: %w", err)
+	}
+
+	path := dataTablePath(instanceID)
+
+	data := make([]byte, 2)
+	binary.LittleEndian.PutUint16(data, tagIndex)
+
+	_, err = client.GenericCIPMessage(CIPService_RemoveTagFromBuffer, path, data)
+	if err != nil {
+		return fmt.Errorf("datatable remove tag failed: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// High-level API
+// ---------------------------------------------------------------------------
+
+// NewDataTableBuffer creates a new datatable buffer on the PLC by sending a CIP
+// Create (0x08) service to class 0xB2. The returned DataTableBuffer tracks the
+// buffer instance and all tags added to it.
+//
+// Call Close() when finished to delete the buffer and free PLC resources.
+//
+// Example:
+//
+//	buf, err := client.NewDataTableBuffer()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer buf.Close()
+//
+//	buf.AddTag("MyDINT", gologix.CIPTypeDINT)
+//	values, err := buf.ReadAll()
+func (client *Client) NewDataTableBuffer() (*DataTableBuffer, error) {
+	instanceID, err := client.CreateDataTableBuffer()
+	if err != nil {
+		return nil, err
+	}
+	return &DataTableBuffer{
+		client:     client,
+		instanceID: instanceID,
+		tags:       make([]DataTableBufferTag, 0),
+		created:    true,
+		expansions: make(map[string][]string),
+	}, nil
+}
+
+// AddTag adds a single tag to the datatable buffer by its symbolic name and CIP type.
+// The tag is sent to the PLC via service 0x4E and the PLC-assigned batch index is recorded.
+//
+// The IOI is built using the client's standard IOI encoding, which supports both
+// symbolic (0x91 segments) and instance-optimized (class 0x6B) addressing.
+func (buf *DataTableBuffer) AddTag(tagName string, cipType CIPType) error {
+	if !buf.created {
+		return fmt.Errorf("datatable buffer not created")
+	}
+
+	ioi, err := buf.client.newIOI(tagName, cipType)
+	if err != nil {
+		return fmt.Errorf("could not create IOI for tag %q: %w", tagName, err)
+	}
+
+	typeSize, err := buf.resolveTypeSize(tagName, cipType)
+	if err != nil {
+		return fmt.Errorf("tag %q: %w", tagName, err)
+	}
+
+	batchID, err := buf.client.DataTableAddTag(buf.instanceID, typeSize, ioi.Bytes())
+	if err != nil {
+		return fmt.Errorf("could not add tag %q to buffer: %w", tagName, err)
+	}
+
+	buf.tags = append(buf.tags, DataTableBufferTag{
+		Name:         tagName,
+		CIPType:      cipType,
+		DataTypeSize: typeSize,
+		index:        uint16(len(buf.tags) + 1),
+		ioi:          ioi.Bytes(),
+		batchID:      batchID,
+	})
+
+	return nil
+}
+
+// AddTags adds multiple tags to the datatable buffer in a single 0x4E call.
+// Each tag carries its own dataTypeSize and IOI EPath — mixed type sizes are
+// supported in one call (confirmed via pcap).
+//
+// Because tags is a map, iteration order (and therefore the tag position in the
+// buffer) is non-deterministic. Use AddTag in a loop if you need a specific ordering.
+func (buf *DataTableBuffer) AddTags(tags map[string]CIPType) error {
+	if !buf.created {
+		return fmt.Errorf("datatable buffer not created")
+	}
+
+	type preparedTag struct {
+		name     string
+		cipType  CIPType
+		typeSize uint16
+		ioi      []byte
+	}
+
+	// Resolve IOI and type size for each tag.
+	prepared := make([]preparedTag, 0, len(tags))
+	for name, cipType := range tags {
+		ioi, err := buf.client.newIOI(name, cipType)
+		if err != nil {
+			return fmt.Errorf("could not create IOI for tag %q: %w", name, err)
+		}
+		typeSize, err := buf.resolveTypeSize(name, cipType)
+		if err != nil {
+			return fmt.Errorf("tag %q: %w", name, err)
+		}
+		prepared = append(prepared, preparedTag{
+			name:     name,
+			cipType:  cipType,
+			typeSize: typeSize,
+			ioi:      ioi.Bytes(),
+		})
+	}
+
+	// Build entries for a single DataTableAddTags call.
+	entries := make([]addTagEntry, len(prepared))
+	for i, t := range prepared {
+		entries[i] = addTagEntry{
+			dataTypeSize: t.typeSize,
+			ioi:          t.ioi,
+		}
+	}
+
+	batchID, err := buf.client.DataTableAddTags(buf.instanceID, entries)
+	if err != nil {
+		return fmt.Errorf("could not add tags to buffer: %w", err)
+	}
+
+	// Assign sequential indices and record the batch ID for read parsing.
+	baseIndex := uint16(len(buf.tags) + 1)
+	for i, t := range prepared {
+		buf.tags = append(buf.tags, DataTableBufferTag{
+			Name:         t.name,
+			CIPType:      t.cipType,
+			DataTypeSize: t.typeSize,
+			index:        baseIndex + uint16(i),
+			ioi:          t.ioi,
+			batchID:      batchID,
+		})
+	}
+
+	return nil
+}
+
+// ReadAll reads all tag values from the datatable buffer in a single CIP request
+// (service 0x4C) and returns them as a map from tag name to the decoded Go value.
+//
+// # Response layout
+//
+// The PLC returns a byte stream grouped by 0x4E add-tag calls (batches).
+// For each batch (in the order the 0x4E calls were made):
+//
+//	[2 bytes LE] batch/entry index (1, 2, ...)
+//	For each tag in that batch (in the order they were added):
+//	  [DataTypeSize bytes] tag value
+//
+// The 2-byte entry header appears once per 0x4E call, NOT per tag. When all
+// tags are added in a single AddTags call, there is exactly one entry header
+// followed by all tag values concatenated. When using AddTag individually,
+// each tag gets its own entry header.
+//
+// Tags are sorted by index (insertion order) to match the PLC's output order.
+// We track batch boundaries via each tag's batchID field, skipping the 2-byte
+// entry header whenever we encounter a new batch.
+//
+// For STRING/Struct types the slot is a fixed size determined at AddTag time
+// (e.g. 88 bytes for standard AB STRING), but the actual string content is
+// variable-length within that slot: [4-byte uint32 LEN][LEN chars][padding].
+// decodeDataTableValue reads LEN to extract only the meaningful characters.
+func (buf *DataTableBuffer) ReadAll() (map[string]any, error) {
+	if !buf.created {
+		return nil, fmt.Errorf("datatable buffer not created")
+	}
+	if len(buf.tags) == 0 {
+		return nil, fmt.Errorf("no tags in datatable buffer")
+	}
+
+	resp, err := buf.client.DataTableReadBuffer(buf.instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort tags by index so we walk the response in the order the PLC emits entries.
+	sorted := make([]DataTableBufferTag, len(buf.tags))
+	copy(sorted, buf.tags)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].index < sorted[j].index
+	})
+
+	result := make(map[string]any, len(sorted))
+	currentBatch := uint16(0)
+	for _, tag := range sorted {
+		// When we hit a new batch, skip the 2-byte entry header.
+		if tag.batchID != currentBatch {
+			if _, err := resp.Uint16(); err != nil {
+				return nil, fmt.Errorf("could not read batch header before tag %q: %w", tag.Name, err)
+			}
+			currentBatch = tag.batchID
+		}
+
+		// Read exactly DataTypeSize bytes — this is the fixed slot size for
+		// this tag's type, matching what was sent in the 0x4E Add Tag request.
+		if resp.Pos+int(tag.DataTypeSize) > len(resp.Data) {
+			return nil, fmt.Errorf("not enough data for tag %q (index %d): need %d bytes at offset %d, have %d total",
+				tag.Name, tag.index, tag.DataTypeSize, resp.Pos, len(resp.Data))
+		}
+		raw := make([]byte, tag.DataTypeSize)
+		copy(raw, resp.Data[resp.Pos:resp.Pos+int(tag.DataTypeSize)])
+		resp.Pos += int(tag.DataTypeSize)
+
+		value, err := decodeDataTableValue(tag.CIPType, raw)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode value for tag %q: %w", tag.Name, err)
+		}
+		result[tag.Name] = value
+	}
+
+	return result, nil
+}
+
+// ReadAllRaw reads all tag values from the buffer and returns them as a map
+// from tag name to raw byte slices, without type decoding.
+//
+// The response is parsed identically to ReadAll (see its doc comment for the
+// wire layout), but the raw DataTypeSize bytes for each tag are returned
+// directly instead of being decoded into Go types.
+func (buf *DataTableBuffer) ReadAllRaw() (map[string][]byte, error) {
+	if !buf.created {
+		return nil, fmt.Errorf("datatable buffer not created")
+	}
+	if len(buf.tags) == 0 {
+		return nil, fmt.Errorf("no tags in datatable buffer")
+	}
+
+	resp, err := buf.client.DataTableReadBuffer(buf.instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	sorted := make([]DataTableBufferTag, len(buf.tags))
+	copy(sorted, buf.tags)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].index < sorted[j].index
+	})
+
+	result := make(map[string][]byte, len(sorted))
+	currentBatch := uint16(0)
+	for _, tag := range sorted {
+		// When we hit a new batch, skip the 2-byte entry header (see ReadAll).
+		if tag.batchID != currentBatch {
+			if _, err := resp.Uint16(); err != nil {
+				return nil, fmt.Errorf("could not read batch header before tag %q: %w", tag.Name, err)
+			}
+			currentBatch = tag.batchID
+		}
+
+		if resp.Pos+int(tag.DataTypeSize) > len(resp.Data) {
+			return nil, fmt.Errorf("not enough data for tag %q (index %d): need %d bytes at offset %d, have %d total",
+				tag.Name, tag.index, tag.DataTypeSize, resp.Pos, len(resp.Data))
+		}
+		raw := make([]byte, tag.DataTypeSize)
+		copy(raw, resp.Data[resp.Pos:resp.Pos+int(tag.DataTypeSize)])
+		resp.Pos += int(tag.DataTypeSize)
+		result[tag.Name] = raw
+	}
+
+	return result, nil
+}
+
+// RemoveTag removes a tag from the buffer by its name. Sends service 0x4F with
+// the tag's recorded index and updates the internal tag list.
+func (buf *DataTableBuffer) RemoveTag(tagName string) error {
+	if !buf.created {
+		return fmt.Errorf("datatable buffer not created")
+	}
+
+	idx := -1
+	for i, tag := range buf.tags {
+		if tag.Name == tagName {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return fmt.Errorf("tag %q not found in buffer", tagName)
+	}
+
+	err := buf.client.DataTableRemoveTag(buf.instanceID, buf.tags[idx].index)
+	if err != nil {
+		return fmt.Errorf("could not remove tag %q from buffer: %w", tagName, err)
+	}
+
+	buf.tags = append(buf.tags[:idx], buf.tags[idx+1:]...)
+	return nil
+}
+
+// Close deletes the datatable buffer on the PLC, freeing resources.
+// After Close returns, the buffer instance is invalid and should not be reused.
+// Close is idempotent — calling it on an already-closed buffer is a no-op.
+func (buf *DataTableBuffer) Close() error {
+	if !buf.created {
+		return nil
+	}
+	err := buf.client.DeleteDataTableBuffer(buf.instanceID)
+	buf.created = false
+	if err != nil {
+		return fmt.Errorf("could not delete datatable buffer: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// TagGroup integration
+// ---------------------------------------------------------------------------
+
+// AddTagGroup adds all tags from a TagGroup to this datatable buffer.
+// Args substitute {0}, {1}, ... placeholders in tag names.
+//
+// Multi-element tags (Elements > 1) are expanded into individual buffer tags.
+// For example, a TagDef with Name="EXAMPLE[{0},0]", Type=CIPTypeDINT,
+// Elements=5 and args=[1] adds 5 individual tags: "EXAMPLE[1,0]" through
+// "EXAMPLE[1,4]".
+//
+// All tags are batched into a single AddTags call for efficiency (the protocol
+// allows mixed dataTypeSizes in one 0x4E service request).
+//
+// Can be called multiple times with different args to build up a large buffer:
+//
+//	buf.AddTagGroup(inspPointTags, 1)  // inspection point 1
+//	buf.AddTagGroup(inspPointTags, 2)  // inspection point 2
+//	// buf now has all tags for both points
+func (buf *DataTableBuffer) AddTagGroup(group *TagGroup, args ...any) error {
+	if !buf.created {
+		return fmt.Errorf("datatable buffer not created")
+	}
+
+	// Collect all resolved tag names with their types for batched AddTags.
+	tagMap := make(map[string]CIPType)
+
+	for _, def := range group.defs {
+		resolvedName := formatName(def.Name, args...)
+
+		if def.Elements > 1 {
+			expanded := expandArrayTag(resolvedName, def.Elements)
+			buf.expansions[resolvedName] = expanded
+			for _, name := range expanded {
+				tagMap[name] = def.Type
+			}
+		} else {
+			buf.expansions[resolvedName] = []string{resolvedName}
+			tagMap[resolvedName] = def.Type
+		}
+	}
+
+	return buf.AddTags(tagMap)
+}
+
+// ReadAllTyped reads all tag values from the buffer in a single CIP request
+// and returns a TagGroupResult with typed accessors.
+//
+// Multi-element tags that were added via AddTagGroup are automatically
+// re-collapsed from individual values into slices. For example, if
+// "EXAMPLE[1,0]" was expanded into 5 individual tags during AddTagGroup,
+// the result will contain "EXAMPLE[1,0]" → []any{val0, val1, ..., val4}.
+//
+// Tags added via the plain AddTag/AddTags methods (not through a TagGroup)
+// are included as-is in the result.
+func (buf *DataTableBuffer) ReadAllTyped() (*TagGroupResult, error) {
+	rawValues, err := buf.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	// If no TagGroup expansions were recorded, just wrap the raw values.
+	if len(buf.expansions) == 0 {
+		return &TagGroupResult{values: rawValues}, nil
+	}
+
+	// Build the result, collapsing expanded multi-element tags back into slices.
+	result := make(map[string]any, len(rawValues))
+
+	// Track which raw keys have been consumed by expansions.
+	consumed := make(map[string]bool)
+
+	for baseName, expanded := range buf.expansions {
+		if len(expanded) > 1 {
+			// Multi-element: collapse into a slice.
+			slice := make([]any, len(expanded))
+			for i, name := range expanded {
+				v, ok := rawValues[name]
+				if !ok {
+					return nil, fmt.Errorf("expanded tag %q not found in buffer response", name)
+				}
+				slice[i] = v
+				consumed[name] = true
+			}
+			result[baseName] = slice
+		} else if len(expanded) == 1 {
+			// Scalar from TagGroup: pass through directly.
+			v, ok := rawValues[expanded[0]]
+			if !ok {
+				return nil, fmt.Errorf("tag %q not found in buffer response", expanded[0])
+			}
+			result[baseName] = v
+			consumed[expanded[0]] = true
+		}
+	}
+
+	// Include any tags that were added via plain AddTag (not through a TagGroup).
+	for name, val := range rawValues {
+		if !consumed[name] {
+			result[name] = val
+		}
+	}
+
+	return &TagGroupResult{values: result}, nil
+}

--- a/datatable_test.go
+++ b/datatable_test.go
@@ -1,0 +1,197 @@
+package gologix
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestDataTableTypeSize(t *testing.T) {
+	tests := []struct {
+		cipType  CIPType
+		expected uint16
+	}{
+		{CIPTypeBOOL, 1},
+		{CIPTypeSINT, 1},
+		{CIPTypeBYTE, 1},
+		{CIPTypeUSINT, 1},
+		{CIPTypeINT, 2},
+		{CIPTypeUINT, 2},
+		{CIPTypeDINT, 4},
+		{CIPTypeUDINT, 4},
+		{CIPTypeREAL, 4},
+		{CIPTypeLINT, 8},
+		{CIPTypeULINT, 8},
+		{CIPTypeLREAL, 8},
+		{CIPTypeLWORD, 8},
+		{CIPTypeSTRING, 88},
+		{CIPTypeStruct, 88},
+	}
+
+	for _, tt := range tests {
+		size, err := dataTableTypeSize(tt.cipType)
+		if err != nil {
+			t.Errorf("dataTableTypeSize(%v) returned error: %v", tt.cipType, err)
+			continue
+		}
+		if size != tt.expected {
+			t.Errorf("dataTableTypeSize(%v) = %d, want %d", tt.cipType, size, tt.expected)
+		}
+	}
+}
+
+func TestDataTableTypeSizeUnsupported(t *testing.T) {
+	_, err := dataTableTypeSize(CIPTypeUnknown)
+	if err == nil {
+		t.Error("dataTableTypeSize(CIPTypeUnknown) should return error")
+	}
+}
+
+func TestDataTablePath(t *testing.T) {
+	tests := []struct {
+		instanceID uint16
+		expected   []byte
+	}{
+		{0x0000, []byte{0x20, 0xB2, 0x25, 0x00, 0x00, 0x00}},
+		{0x0021, []byte{0x20, 0xB2, 0x25, 0x00, 0x21, 0x00}},
+		{0x1234, []byte{0x20, 0xB2, 0x25, 0x00, 0x34, 0x12}},
+		{0xFFFF, []byte{0x20, 0xB2, 0x25, 0x00, 0xFF, 0xFF}},
+	}
+
+	for _, tt := range tests {
+		path := dataTablePath(tt.instanceID)
+		if !bytes.Equal(path, tt.expected) {
+			t.Errorf("dataTablePath(0x%04X) = %X, want %X", tt.instanceID, path, tt.expected)
+		}
+	}
+}
+
+func TestDataTablePathLength(t *testing.T) {
+	// Path must always be 6 bytes = 3 words
+	path := dataTablePath(0x0021)
+	if len(path) != 6 {
+		t.Errorf("dataTablePath should return 6 bytes, got %d", len(path))
+	}
+	// Path size in words should be 3
+	if len(path)/2 != 3 {
+		t.Errorf("dataTablePath word count should be 3, got %d", len(path)/2)
+	}
+}
+
+func TestDecodeDataTableValueDINT(t *testing.T) {
+	raw := make([]byte, 4)
+	binary.LittleEndian.PutUint32(raw, uint32(0x12345678))
+
+	val, err := decodeDataTableValue(CIPTypeDINT, raw)
+	if err != nil {
+		t.Fatalf("decodeDataTableValue(DINT) error: %v", err)
+	}
+	dint, ok := val.(int32)
+	if !ok {
+		t.Fatalf("expected int32, got %T", val)
+	}
+	if dint != 0x12345678 {
+		t.Errorf("expected 0x12345678, got 0x%X", dint)
+	}
+}
+
+func TestDecodeDataTableValueREAL(t *testing.T) {
+	raw := make([]byte, 4)
+	binary.LittleEndian.PutUint32(raw, 0x41200000) // 10.0 in IEEE 754
+
+	val, err := decodeDataTableValue(CIPTypeREAL, raw)
+	if err != nil {
+		t.Fatalf("decodeDataTableValue(REAL) error: %v", err)
+	}
+	real, ok := val.(float32)
+	if !ok {
+		t.Fatalf("expected float32, got %T", val)
+	}
+	if real != 10.0 {
+		t.Errorf("expected 10.0, got %f", real)
+	}
+}
+
+func TestDecodeDataTableValueINT(t *testing.T) {
+	raw := make([]byte, 2)
+	binary.LittleEndian.PutUint16(raw, uint16(0x00FF)) // 255 as int16
+
+	val, err := decodeDataTableValue(CIPTypeINT, raw)
+	if err != nil {
+		t.Fatalf("decodeDataTableValue(INT) error: %v", err)
+	}
+	intVal, ok := val.(int16)
+	if !ok {
+		t.Fatalf("expected int16, got %T", val)
+	}
+	if intVal != 255 {
+		t.Errorf("expected 255, got %d", intVal)
+	}
+}
+
+func TestDecodeDataTableValueBOOL(t *testing.T) {
+	val, err := decodeDataTableValue(CIPTypeBOOL, []byte{0x01})
+	if err != nil {
+		t.Fatalf("decodeDataTableValue(BOOL) error: %v", err)
+	}
+	boolVal, ok := val.(bool)
+	if !ok {
+		t.Fatalf("expected bool, got %T", val)
+	}
+	if !boolVal {
+		t.Error("expected true, got false")
+	}
+}
+
+func TestDecodeDataTableValueSTRING(t *testing.T) {
+	// Standard AB STRING: 4 byte length + 82 byte data + 2 pad = 88 bytes
+	raw := make([]byte, 88)
+	binary.LittleEndian.PutUint32(raw[0:4], 5) // length = 5
+	copy(raw[4:9], "Hello")                     // "Hello"
+
+	val, err := decodeDataTableValue(CIPTypeSTRING, raw)
+	if err != nil {
+		t.Fatalf("decodeDataTableValue(STRING) error: %v", err)
+	}
+	str, ok := val.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", val)
+	}
+	if str != "Hello" {
+		t.Errorf("expected %q, got %q", "Hello", str)
+	}
+}
+
+func TestDecodeDataTableValueSTRINGEmpty(t *testing.T) {
+	raw := make([]byte, 88)
+	binary.LittleEndian.PutUint32(raw[0:4], 0) // length = 0
+
+	val, err := decodeDataTableValue(CIPTypeSTRING, raw)
+	if err != nil {
+		t.Fatalf("decodeDataTableValue(STRING empty) error: %v", err)
+	}
+	str, ok := val.(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", val)
+	}
+	if str != "" {
+		t.Errorf("expected empty string, got %q", str)
+	}
+}
+
+func TestDecodeDataTableValueLREAL(t *testing.T) {
+	raw := make([]byte, 8)
+	binary.LittleEndian.PutUint64(raw, 0x4024000000000000) // 10.0 in float64
+
+	val, err := decodeDataTableValue(CIPTypeLREAL, raw)
+	if err != nil {
+		t.Fatalf("decodeDataTableValue(LREAL) error: %v", err)
+	}
+	lreal, ok := val.(float64)
+	if !ok {
+		t.Fatalf("expected float64, got %T", val)
+	}
+	if lreal != 10.0 {
+		t.Errorf("expected 10.0, got %f", lreal)
+	}
+}

--- a/examples/DataTableBuffer/main.go
+++ b/examples/DataTableBuffer/main.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/danomagnum/gologix"
+)
+
+// Demo program for reading multiple tags at once using a DataTable buffer.
+//
+// A DataTable buffer (CIP class 0xB2) is created on the PLC, tags are associated
+// with it, and then all tag values are read in a single request. This is the
+// same mechanism RSLinx uses for grouped/trend reads.
+//
+// Three approaches are demonstrated:
+//  1. AddTag      — add tags one at a time (separate 0x4E calls)
+//  2. AddTags     — batch-add a map of tags in a single 0x4E call
+//  3. AddTagGroup — schema-based with parameter substitution and multi-element expansion
+func main() {
+
+	// Setup the client.
+	client := gologix.NewClient("192.168.2.241")
+
+	err := client.Connect()
+	if err != nil {
+		log.Printf("Error opening client. %v", err)
+		return
+	}
+	defer client.Disconnect()
+
+	// =========================================================================
+	// 1. AddTag — add tags one at a time
+	// =========================================================================
+	// Each call sends a separate CIP 0x4E message to the PLC.
+
+	fmt.Println("=== AddTag (one at a time) ===")
+
+	buf, err := client.NewDataTableBuffer()
+	if err != nil {
+		log.Fatalf("Error creating datatable buffer: %v", err)
+	}
+
+	err = buf.AddTag("TestDint", gologix.CIPTypeDINT)
+	if err != nil {
+		log.Fatalf("Error adding DINT tag: %v", err)
+	}
+
+	err = buf.AddTag("TestReal", gologix.CIPTypeREAL)
+	if err != nil {
+		log.Fatalf("Error adding REAL tag: %v", err)
+	}
+
+	err = buf.AddTag("TestInt", gologix.CIPTypeINT)
+	if err != nil {
+		log.Fatalf("Error adding INT tag: %v", err)
+	}
+
+	// Read all tag values in a single request.
+	// The PLC returns all values concatenated; ReadAll() splits them by
+	// the tracked type sizes and decodes into Go types.
+	values, err := buf.ReadAll()
+	if err != nil {
+		log.Fatalf("Error reading all: %v", err)
+	}
+
+	for name, val := range values {
+		fmt.Printf("  %s = %v\n", name, val)
+	}
+
+	buf.Close()
+
+	// =========================================================================
+	// 2. AddTags — batch-add multiple tags in a single 0x4E call
+	// =========================================================================
+	// All tags are sent to the PLC in one message, which is more efficient
+	// than calling AddTag repeatedly. Mixed type sizes are fully supported.
+
+	fmt.Println("\n=== AddTags (batch map) ===")
+
+	buf, err = client.NewDataTableBuffer()
+	if err != nil {
+		log.Fatalf("Error creating datatable buffer: %v", err)
+	}
+
+	err = buf.AddTags(map[string]gologix.CIPType{
+		"TestDint":   gologix.CIPTypeDINT,
+		"TestReal":   gologix.CIPTypeREAL,
+		"TestInt":    gologix.CIPTypeINT,
+		"TestString": gologix.CIPTypeSTRING,
+	})
+	if err != nil {
+		log.Fatalf("Error batch-adding tags: %v", err)
+	}
+
+	values, err = buf.ReadAll()
+	if err != nil {
+		log.Fatalf("Error reading all: %v", err)
+	}
+
+	for name, val := range values {
+		fmt.Printf("  %s = %v\n", name, val)
+	}
+
+	buf.Close()
+
+	// =========================================================================
+	// 3. AddTagGroup — schema with parameter substitution and array expansion
+	// =========================================================================
+	// A TagGroup defines a reusable schema of tag definitions. Tag names can
+	// contain {0}, {1}, ... placeholders that are substituted when calling
+	// AddTagGroup. Tags with Elements > 1 are automatically expanded into
+	// individual buffer entries (e.g., Elements=3 creates 3 sequential tags).
+	//
+	// ReadAllTyped() returns a TagGroupResult with typed accessors and
+	// automatically re-collapses multi-element tags back into slices.
+
+	fmt.Println("\n=== AddTagGroup (schema with expansion) ===")
+
+	buf, err = client.NewDataTableBuffer()
+	if err != nil {
+		log.Fatalf("Error creating datatable buffer: %v", err)
+	}
+
+	group := gologix.NewTagGroup(
+		// Elements=3 expands to: TestDintArray[0], TestDintArray[1], TestDintArray[2]
+		gologix.TagDef{Name: "TestDintArray[{0}]", Type: gologix.CIPTypeDINT, Elements: 3},
+		// Elements=1 (or omitted) adds a single tag as-is.
+		gologix.TagDef{Name: "TestReal", Type: gologix.CIPTypeREAL},
+	)
+
+	// Substitute {0} → 0 and add all expanded tags in a single 0x4E call.
+	err = buf.AddTagGroup(group, 0)
+	if err != nil {
+		log.Fatalf("Error adding tag group: %v", err)
+	}
+
+	// ReadAllTyped returns typed accessors and auto-collapses multi-element
+	// tags back into slices.
+	result, err := buf.ReadAllTyped()
+	if err != nil {
+		log.Fatalf("Error reading typed: %v", err)
+	}
+
+	// Multi-element tag → slice accessor
+	dints, err := result.Int32Slice("TestDintArray[0]")
+	if err != nil {
+		log.Fatalf("Error getting int32 slice: %v", err)
+	}
+	fmt.Printf("  TestDintArray[0..2] = %v\n", dints)
+
+	// Single tag → scalar accessor
+	realVal, err := result.Float32("TestReal")
+	if err != nil {
+		log.Fatalf("Error getting float32: %v", err)
+	}
+	fmt.Printf("  TestReal = %v\n", realVal)
+
+	buf.Close()
+}

--- a/listidentity.go
+++ b/listidentity.go
@@ -57,11 +57,11 @@ func (client *Client) ListIdentity() (*listIdentityResponeBody, error) {
 		return nil, fmt.Errorf("couldn't parse items. %w", err)
 	}
 
-	if len(items) != 1 {
-		return nil, fmt.Errorf("expected 1 item, got %d", len(items))
+	if len(items) < 1 {
+		return nil, fmt.Errorf("expected at least 1 item, got %d", len(items))
 	}
 
-	// The response only contains one item.
+	// Parse the first identity item (PLCs with dual-port Ethernet may return multiple).
 	response := listIdentityResponeBody{}
 	err = response.ParseFromBytes(items[0].Data)
 	if err != nil {

--- a/services.go
+++ b/services.go
@@ -143,6 +143,7 @@ const (
 	CIPService_Write                    CIPService = 0x4D
 	CIPService_ForwardClose             CIPService = 0x4E
 	cipService_ReadModWrite             CIPService = 0x4E
+	CIPService_RemoveTagFromBuffer      CIPService = 0x4F // Remove tag from datatable buffer by index
 	CIPService_GetConnectionOwner       CIPService = 0x5A
 	CIPService_ForwardOpen              CIPService = 0x54
 	CIPService_LargeForwardOpen         CIPService = 0x5B

--- a/taggroup.go
+++ b/taggroup.go
@@ -1,0 +1,330 @@
+package gologix
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TagDef describes a single PLC tag to read. Name may contain {0}, {1}, ...
+// placeholders that are substituted at read time with runtime arguments.
+type TagDef struct {
+	Name     string  // tag path, e.g. "STATS[{0},0]"
+	Type     CIPType // CIPTypeDINT, CIPTypeREAL, CIPTypeSTRING, etc.
+	Elements int     // number of elements to read. 0 or 1 = scalar, >1 = array
+}
+
+// TagGroup is a reusable schema of tag definitions. Define once, read
+// repeatedly with different parameter substitutions via ReadTagGroup
+// or DataTableBuffer.AddTagGroup.
+type TagGroup struct {
+	defs []TagDef
+}
+
+// NewTagGroup creates a TagGroup from one or more TagDefs.
+// Elements values of 0 are normalized to 1 (scalar).
+func NewTagGroup(defs ...TagDef) *TagGroup {
+	normalized := make([]TagDef, len(defs))
+	copy(normalized, defs)
+	for i := range normalized {
+		if normalized[i].Elements <= 0 {
+			normalized[i].Elements = 1
+		}
+	}
+	return &TagGroup{defs: normalized}
+}
+
+// Defs returns a copy of the tag definitions.
+func (g *TagGroup) Defs() []TagDef {
+	out := make([]TagDef, len(g.defs))
+	copy(out, g.defs)
+	return out
+}
+
+// formatName replaces {0}, {1}, ... placeholders in a tag name template
+// with the provided arguments.
+func formatName(template string, args ...any) string {
+	s := template
+	for i, arg := range args {
+		placeholder := fmt.Sprintf("{%d}", i)
+		s = strings.ReplaceAll(s, placeholder, fmt.Sprintf("%v", arg))
+	}
+	return s
+}
+
+// zeroValueForTagDef returns a zero-valued Go variable matching the TagDef's
+// CIP type and element count. The returned value is suitable for passing to
+// ReadMap, which uses GoVarToCIPType() to infer the CIP type from the Go type.
+func zeroValueForTagDef(def TagDef) any {
+	if def.Elements > 1 {
+		switch def.Type {
+		case CIPTypeBOOL:
+			return make([]bool, def.Elements)
+		case CIPTypeSINT:
+			return make([]int8, def.Elements)
+		case CIPTypeBYTE, CIPTypeUSINT:
+			return make([]byte, def.Elements)
+		case CIPTypeINT:
+			return make([]int16, def.Elements)
+		case CIPTypeUINT:
+			return make([]uint16, def.Elements)
+		case CIPTypeDINT:
+			return make([]int32, def.Elements)
+		case CIPTypeUDINT, CIPTypeDWORD:
+			return make([]uint32, def.Elements)
+		case CIPTypeLINT:
+			return make([]int64, def.Elements)
+		case CIPTypeLWORD, CIPTypeULINT:
+			return make([]uint64, def.Elements)
+		case CIPTypeREAL:
+			return make([]float32, def.Elements)
+		case CIPTypeLREAL:
+			return make([]float64, def.Elements)
+		case CIPTypeSTRING:
+			return make([]string, def.Elements)
+		default:
+			return make([]int32, def.Elements)
+		}
+	}
+	switch def.Type {
+	case CIPTypeBOOL:
+		return false
+	case CIPTypeSINT:
+		return int8(0)
+	case CIPTypeBYTE, CIPTypeUSINT:
+		return byte(0)
+	case CIPTypeINT:
+		return int16(0)
+	case CIPTypeUINT, CIPTypeWORD:
+		return uint16(0)
+	case CIPTypeDINT:
+		return int32(0)
+	case CIPTypeUDINT, CIPTypeDWORD:
+		return uint32(0)
+	case CIPTypeLINT:
+		return int64(0)
+	case CIPTypeLWORD, CIPTypeULINT:
+		return uint64(0)
+	case CIPTypeREAL:
+		return float32(0)
+	case CIPTypeLREAL:
+		return float64(0)
+	case CIPTypeSTRING:
+		return ""
+	default:
+		return int32(0)
+	}
+}
+
+// expandArrayTag takes a resolved tag name like "STATS[1,0]" and a count,
+// and returns individual tag names with the last array dimension incremented:
+// ["STATS[1,0]", "STATS[1,1]", ..., "STATS[1,4]"]
+func expandArrayTag(baseName string, count int) []string {
+	if count <= 1 {
+		return []string{baseName}
+	}
+
+	tag, err := parse_tag_name(baseName)
+	if err != nil || tag.Array_Order == nil || len(tag.Array_Order) == 0 {
+		// No array index found — just return the base name repeated.
+		// This shouldn't happen in normal use.
+		result := make([]string, count)
+		for i := range result {
+			result[i] = baseName
+		}
+		return result
+	}
+
+	// Find the bracket position to reconstruct the name
+	bracketPos := strings.LastIndex(baseName, "[")
+	if bracketPos < 0 {
+		result := make([]string, count)
+		for i := range result {
+			result[i] = baseName
+		}
+		return result
+	}
+	prefix := baseName[:bracketPos]
+
+	lastDim := len(tag.Array_Order) - 1
+	baseIndex := tag.Array_Order[lastDim]
+
+	result := make([]string, count)
+	for i := 0; i < count; i++ {
+		indices := make([]string, len(tag.Array_Order))
+		for d := 0; d < lastDim; d++ {
+			indices[d] = fmt.Sprintf("%d", tag.Array_Order[d])
+		}
+		indices[lastDim] = fmt.Sprintf("%d", baseIndex+i)
+		result[i] = fmt.Sprintf("%s[%s]", prefix, strings.Join(indices, ","))
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// TagGroupResult — typed accessors for read results
+// ---------------------------------------------------------------------------
+
+// TagGroupResult holds the results of a TagGroup read. Values are stored
+// by resolved tag name (after parameter substitution).
+type TagGroupResult struct {
+	values map[string]any
+}
+
+// Raw returns the underlying map of tag name → value.
+func (r *TagGroupResult) Raw() map[string]any {
+	return r.values
+}
+
+// Value returns the raw any value for a tag name.
+func (r *TagGroupResult) Value(name string) (any, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return nil, fmt.Errorf("tag %q not found in result", name)
+	}
+	return v, nil
+}
+
+// String returns the string value for the given resolved tag name.
+func (r *TagGroupResult) String(name string) (string, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return "", fmt.Errorf("tag %q not found in result", name)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("tag %q is %T, not string", name, v)
+	}
+	return s, nil
+}
+
+// Bool returns the bool value for the given resolved tag name.
+func (r *TagGroupResult) Bool(name string) (bool, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return false, fmt.Errorf("tag %q not found in result", name)
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false, fmt.Errorf("tag %q is %T, not bool", name, v)
+	}
+	return b, nil
+}
+
+// Int16 returns the int16 value for the given resolved tag name.
+func (r *TagGroupResult) Int16(name string) (int16, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return 0, fmt.Errorf("tag %q not found in result", name)
+	}
+	i, ok := v.(int16)
+	if !ok {
+		return 0, fmt.Errorf("tag %q is %T, not int16", name, v)
+	}
+	return i, nil
+}
+
+// Int32 returns the int32 value for the given resolved tag name.
+func (r *TagGroupResult) Int32(name string) (int32, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return 0, fmt.Errorf("tag %q not found in result", name)
+	}
+	i, ok := v.(int32)
+	if !ok {
+		return 0, fmt.Errorf("tag %q is %T, not int32", name, v)
+	}
+	return i, nil
+}
+
+// Uint32 returns the uint32 value for the given resolved tag name.
+// Also handles int32→uint32 conversion since gologix returns int32 for
+// DINT tags even when the PLC type is UDINT.
+func (r *TagGroupResult) Uint32(name string) (uint32, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return 0, fmt.Errorf("tag %q not found in result", name)
+	}
+	switch x := v.(type) {
+	case uint32:
+		return x, nil
+	case int32:
+		return uint32(x), nil
+	default:
+		return 0, fmt.Errorf("tag %q is %T, not uint32 or int32", name, v)
+	}
+}
+
+// Float32 returns the float32 value for the given resolved tag name.
+func (r *TagGroupResult) Float32(name string) (float32, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return 0, fmt.Errorf("tag %q not found in result", name)
+	}
+	f, ok := v.(float32)
+	if !ok {
+		return 0, fmt.Errorf("tag %q is %T, not float32", name, v)
+	}
+	return f, nil
+}
+
+// Float64 returns the float64 value for the given resolved tag name.
+func (r *TagGroupResult) Float64(name string) (float64, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return 0, fmt.Errorf("tag %q not found in result", name)
+	}
+	f, ok := v.(float64)
+	if !ok {
+		return 0, fmt.Errorf("tag %q is %T, not float64", name, v)
+	}
+	return f, nil
+}
+
+// Int32Slice returns a []int32 for a multi-element tag read.
+// Handles both []any (from ReadMap) and []int32 (from DataTable) return types.
+func (r *TagGroupResult) Int32Slice(name string) ([]int32, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return nil, fmt.Errorf("tag %q not found in result", name)
+	}
+	switch x := v.(type) {
+	case []int32:
+		return x, nil
+	case []any:
+		result := make([]int32, len(x))
+		for i, elem := range x {
+			val, ok := elem.(int32)
+			if !ok {
+				return nil, fmt.Errorf("tag %q element %d is %T, not int32", name, i, elem)
+			}
+			result[i] = val
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("tag %q is %T, not []int32 or []any", name, v)
+	}
+}
+
+// Float32Slice returns a []float32 for a multi-element tag read.
+func (r *TagGroupResult) Float32Slice(name string) ([]float32, error) {
+	v, ok := r.values[name]
+	if !ok {
+		return nil, fmt.Errorf("tag %q not found in result", name)
+	}
+	switch x := v.(type) {
+	case []float32:
+		return x, nil
+	case []any:
+		result := make([]float32, len(x))
+		for i, elem := range x {
+			val, ok := elem.(float32)
+			if !ok {
+				return nil, fmt.Errorf("tag %q element %d is %T, not float32", name, i, elem)
+			}
+			result[i] = val
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("tag %q is %T, not []float32 or []any", name, v)
+	}
+}

--- a/taggroup_readmap.go
+++ b/taggroup_readmap.go
@@ -1,0 +1,40 @@
+package gologix
+
+import "fmt"
+
+// ReadTagGroup reads all tags defined in the TagGroup in a single network
+// call (or the minimum number of calls if tags exceed the connection size
+// limit). The args are substituted into {0}, {1}, ... placeholders in tag names.
+//
+// Internally this builds a ReadMap call using the existing CIP multi-service
+// (0x0A) batching and auto-splitting logic.
+//
+// Example:
+//
+//	group := gologix.NewTagGroup(
+//	    gologix.TagDef{Name: "RATE[{0}]", Type: gologix.CIPTypeREAL},
+//	    gologix.TagDef{Name: "STATS[{0},0]", Type: gologix.CIPTypeDINT, Elements: 5},
+//	)
+//	result, err := client.ReadTagGroup(group, 1)
+//	rate, _ := result.Float32("RATE[1]")
+//	stats, _ := result.Int32Slice("STATS[1,0]")
+func (client *Client) ReadTagGroup(group *TagGroup, args ...any) (*TagGroupResult, error) {
+	err := client.checkConnection()
+	if err != nil {
+		return nil, fmt.Errorf("could not start tag group read: %w", err)
+	}
+
+	m := make(map[string]any, len(group.defs))
+
+	for _, def := range group.defs {
+		name := formatName(def.Name, args...)
+		m[name] = zeroValueForTagDef(def)
+	}
+
+	err = client.ReadMap(m)
+	if err != nil {
+		return nil, fmt.Errorf("tag group read failed: %w", err)
+	}
+
+	return &TagGroupResult{values: m}, nil
+}

--- a/taggroup_test.go
+++ b/taggroup_test.go
@@ -1,0 +1,293 @@
+package gologix
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFormatName(t *testing.T) {
+	tests := []struct {
+		template string
+		args     []any
+		expected string
+	}{
+		{"Rate[{0}]", []any{1}, "Rate[1]"},
+		{"STATS[{0},{1}]", []any{3, 0}, "STATS[3,0]"},
+		{"NoPlaceholder", []any{1}, "NoPlaceholder"},
+		{"String[{0},0]", []any{42}, "String[42,0]"},
+		{"{0}_{1}", []any{"Tag", "Name"}, "Tag_Name"},
+		{"Simple", nil, "Simple"},
+		{"Multi_{0}_{0}", []any{5}, "Multi_5_5"},
+	}
+
+	for _, tt := range tests {
+		result := formatName(tt.template, tt.args...)
+		if result != tt.expected {
+			t.Errorf("formatName(%q, %v) = %q, want %q", tt.template, tt.args, result, tt.expected)
+		}
+	}
+}
+
+func TestNewTagGroupNormalize(t *testing.T) {
+	g := NewTagGroup(
+		TagDef{Name: "A", Type: CIPTypeDINT, Elements: 0},
+		TagDef{Name: "B", Type: CIPTypeREAL, Elements: -1},
+		TagDef{Name: "C", Type: CIPTypeINT, Elements: 5},
+	)
+
+	defs := g.Defs()
+	if defs[0].Elements != 1 {
+		t.Errorf("Elements=0 should normalize to 1, got %d", defs[0].Elements)
+	}
+	if defs[1].Elements != 1 {
+		t.Errorf("Elements=-1 should normalize to 1, got %d", defs[1].Elements)
+	}
+	if defs[2].Elements != 5 {
+		t.Errorf("Elements=5 should stay 5, got %d", defs[2].Elements)
+	}
+}
+
+func TestNewTagGroupDefsIsCopy(t *testing.T) {
+	g := NewTagGroup(TagDef{Name: "A", Type: CIPTypeDINT})
+	defs := g.Defs()
+	defs[0].Name = "Modified"
+	if g.defs[0].Name == "Modified" {
+		t.Error("Defs() should return a copy, not a reference")
+	}
+}
+
+func TestZeroValueForTagDefScalars(t *testing.T) {
+	tests := []struct {
+		def      TagDef
+		expected any
+	}{
+		{TagDef{Type: CIPTypeBOOL, Elements: 1}, false},
+		{TagDef{Type: CIPTypeSINT, Elements: 1}, int8(0)},
+		{TagDef{Type: CIPTypeBYTE, Elements: 1}, byte(0)},
+		{TagDef{Type: CIPTypeINT, Elements: 1}, int16(0)},
+		{TagDef{Type: CIPTypeUINT, Elements: 1}, uint16(0)},
+		{TagDef{Type: CIPTypeDINT, Elements: 1}, int32(0)},
+		{TagDef{Type: CIPTypeUDINT, Elements: 1}, uint32(0)},
+		{TagDef{Type: CIPTypeLINT, Elements: 1}, int64(0)},
+		{TagDef{Type: CIPTypeLWORD, Elements: 1}, uint64(0)},
+		{TagDef{Type: CIPTypeREAL, Elements: 1}, float32(0)},
+		{TagDef{Type: CIPTypeLREAL, Elements: 1}, float64(0)},
+		{TagDef{Type: CIPTypeSTRING, Elements: 1}, ""},
+	}
+
+	for _, tt := range tests {
+		result := zeroValueForTagDef(tt.def)
+		if reflect.TypeOf(result) != reflect.TypeOf(tt.expected) {
+			t.Errorf("zeroValueForTagDef(%v) type = %T, want %T", tt.def.Type, result, tt.expected)
+		}
+	}
+}
+
+func TestZeroValueForTagDefArrays(t *testing.T) {
+	tests := []struct {
+		def         TagDef
+		expectedLen int
+		expectedTyp string
+	}{
+		{TagDef{Type: CIPTypeDINT, Elements: 5}, 5, "[]int32"},
+		{TagDef{Type: CIPTypeREAL, Elements: 3}, 3, "[]float32"},
+		{TagDef{Type: CIPTypeINT, Elements: 10}, 10, "[]int16"},
+		{TagDef{Type: CIPTypeSTRING, Elements: 2}, 2, "[]string"},
+		{TagDef{Type: CIPTypeBOOL, Elements: 8}, 8, "[]bool"},
+	}
+
+	for _, tt := range tests {
+		result := zeroValueForTagDef(tt.def)
+		rv := reflect.ValueOf(result)
+		if rv.Kind() != reflect.Slice {
+			t.Errorf("zeroValueForTagDef(%v, Elements=%d) should be a slice, got %T", tt.def.Type, tt.def.Elements, result)
+			continue
+		}
+		if rv.Len() != tt.expectedLen {
+			t.Errorf("zeroValueForTagDef(%v, Elements=%d) len = %d, want %d", tt.def.Type, tt.def.Elements, rv.Len(), tt.expectedLen)
+		}
+		if rv.Type().String() != tt.expectedTyp {
+			t.Errorf("zeroValueForTagDef(%v, Elements=%d) type = %s, want %s", tt.def.Type, tt.def.Elements, rv.Type().String(), tt.expectedTyp)
+		}
+	}
+}
+
+func TestExpandArrayTag(t *testing.T) {
+	tests := []struct {
+		baseName string
+		count    int
+		expected []string
+	}{
+		{
+			"STATS[1,0]", 5,
+			[]string{"STATS[1,0]", "STATS[1,1]", "STATS[1,2]", "STATS[1,3]", "STATS[1,4]"},
+		},
+		{
+			"MyArray[0]", 3,
+			[]string{"MyArray[0]", "MyArray[1]", "MyArray[2]"},
+		},
+		{
+			"Tag[2,3,0]", 2,
+			[]string{"Tag[2,3,0]", "Tag[2,3,1]"},
+		},
+		{
+			"Scalar", 1,
+			[]string{"Scalar"},
+		},
+	}
+
+	for _, tt := range tests {
+		result := expandArrayTag(tt.baseName, tt.count)
+		if !reflect.DeepEqual(result, tt.expected) {
+			t.Errorf("expandArrayTag(%q, %d) = %v, want %v", tt.baseName, tt.count, result, tt.expected)
+		}
+	}
+}
+
+func TestExpandArrayTagScalar(t *testing.T) {
+	// Scalar tag (no brackets) — returns the name once
+	result := expandArrayTag("MyTag", 1)
+	if len(result) != 1 || result[0] != "MyTag" {
+		t.Errorf("expandArrayTag(scalar, 1) = %v, want [MyTag]", result)
+	}
+}
+
+func TestTagGroupResultString(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"tag": "hello"}}
+
+	s, err := r.String("tag")
+	if err != nil || s != "hello" {
+		t.Errorf("String() = %q, %v; want hello, nil", s, err)
+	}
+
+	_, err = r.String("missing")
+	if err == nil {
+		t.Error("String(missing) should return error")
+	}
+
+	r2 := &TagGroupResult{values: map[string]any{"tag": int32(5)}}
+	_, err = r2.String("tag")
+	if err == nil {
+		t.Error("String(int32) should return type mismatch error")
+	}
+}
+
+func TestTagGroupResultBool(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"tag": true}}
+
+	b, err := r.Bool("tag")
+	if err != nil || !b {
+		t.Errorf("Bool() = %v, %v; want true, nil", b, err)
+	}
+}
+
+func TestTagGroupResultInt16(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"tag": int16(999)}}
+
+	i, err := r.Int16("tag")
+	if err != nil || i != 999 {
+		t.Errorf("Int16() = %d, %v; want 999, nil", i, err)
+	}
+}
+
+func TestTagGroupResultInt32(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"tag": int32(42)}}
+
+	i, err := r.Int32("tag")
+	if err != nil || i != 42 {
+		t.Errorf("Int32() = %d, %v; want 42, nil", i, err)
+	}
+}
+
+func TestTagGroupResultUint32(t *testing.T) {
+	// Test with uint32
+	r := &TagGroupResult{values: map[string]any{"a": uint32(0x80000001)}}
+	u, err := r.Uint32("a")
+	if err != nil || u != 0x80000001 {
+		t.Errorf("Uint32(uint32) = %d, %v; want %d, nil", u, err, uint32(0x80000001))
+	}
+
+	// Test with int32→uint32 coercion (common: gologix returns int32 for DINT)
+	r2 := &TagGroupResult{values: map[string]any{"b": int32(-1)}}
+	u2, err := r2.Uint32("b")
+	if err != nil || u2 != 0xFFFFFFFF {
+		t.Errorf("Uint32(int32(-1)) = %d, %v; want %d, nil", u2, err, uint32(0xFFFFFFFF))
+	}
+}
+
+func TestTagGroupResultFloat32(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"tag": float32(3.14)}}
+
+	f, err := r.Float32("tag")
+	if err != nil || f != 3.14 {
+		t.Errorf("Float32() = %f, %v; want 3.14, nil", f, err)
+	}
+}
+
+func TestTagGroupResultFloat64(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"tag": float64(3.14159)}}
+
+	f, err := r.Float64("tag")
+	if err != nil || f != 3.14159 {
+		t.Errorf("Float64() = %f, %v; want 3.14159, nil", f, err)
+	}
+}
+
+func TestTagGroupResultInt32Slice(t *testing.T) {
+	// Test with []int32 (from DataTable)
+	r := &TagGroupResult{values: map[string]any{"a": []int32{1, 2, 3}}}
+	s, err := r.Int32Slice("a")
+	if err != nil || !reflect.DeepEqual(s, []int32{1, 2, 3}) {
+		t.Errorf("Int32Slice([]int32) = %v, %v; want [1,2,3], nil", s, err)
+	}
+
+	// Test with []any{int32...} (from ReadMap)
+	r2 := &TagGroupResult{values: map[string]any{"b": []any{int32(10), int32(20)}}}
+	s2, err := r2.Int32Slice("b")
+	if err != nil || !reflect.DeepEqual(s2, []int32{10, 20}) {
+		t.Errorf("Int32Slice([]any) = %v, %v; want [10,20], nil", s2, err)
+	}
+
+	// Test type mismatch within []any
+	r3 := &TagGroupResult{values: map[string]any{"c": []any{int32(1), "bad"}}}
+	_, err = r3.Int32Slice("c")
+	if err == nil {
+		t.Error("Int32Slice with mixed types should return error")
+	}
+}
+
+func TestTagGroupResultFloat32Slice(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"a": []float32{1.0, 2.0}}}
+	s, err := r.Float32Slice("a")
+	if err != nil || !reflect.DeepEqual(s, []float32{1.0, 2.0}) {
+		t.Errorf("Float32Slice([]float32) = %v, %v; want [1.0,2.0], nil", s, err)
+	}
+
+	r2 := &TagGroupResult{values: map[string]any{"b": []any{float32(3.0), float32(4.0)}}}
+	s2, err := r2.Float32Slice("b")
+	if err != nil || !reflect.DeepEqual(s2, []float32{3.0, 4.0}) {
+		t.Errorf("Float32Slice([]any) = %v, %v; want [3.0,4.0], nil", s2, err)
+	}
+}
+
+func TestTagGroupResultValue(t *testing.T) {
+	r := &TagGroupResult{values: map[string]any{"tag": int32(42)}}
+	v, err := r.Value("tag")
+	if err != nil || v != int32(42) {
+		t.Errorf("Value() = %v, %v; want 42, nil", v, err)
+	}
+
+	_, err = r.Value("missing")
+	if err == nil {
+		t.Error("Value(missing) should return error")
+	}
+}
+
+func TestTagGroupResultRaw(t *testing.T) {
+	m := map[string]any{"a": int32(1), "b": "hello"}
+	r := &TagGroupResult{values: m}
+	raw := r.Raw()
+	if raw["a"] != int32(1) || raw["b"] != "hello" {
+		t.Errorf("Raw() returned unexpected map: %v", raw)
+	}
+}


### PR DESCRIPTION
Implement the CIP class 0xB2 datatable protocol for batched tag reads, matching the mechanism RSLinx uses for grouped/trend data. The high-level API supports three usage patterns: AddTag (single), AddTags (batch map), and AddTagGroup (schema with parameter substitution and array expansion).

New files:
- datatable.go: DataTableBuffer lifecycle, low-level CIP services (0x08 Create, 0x4E Add Tag, 0x4C Read, 0x4F Remove, 0x09 Delete), and high-level AddTag/AddTags/ReadAll/ReadAllRaw/ReadAllTyped API
- taggroup.go: TagGroup/TagDef schema types, array expansion, TagGroupResult typed accessors (Int32, Float32, Int32Slice, etc.)
- taggroup_readmap.go: ReadTagGroup via existing ReadMap path
- datatable_test.go, taggroup_test.go: unit tests
- examples/DataTableBuffer/main.go: usage examples for all three APIs

Also:
- Update ListIdentity to accept >=1 items (dual-port Ethernet PLCs return 2)
- Add CipObject_DataTable (0xB2) and CIPService_RemoveTagFromBuffer (0x4F)