### PR TITLE
Add Path Builder type for simplified path generation

### DIFF
--- a/cip_definitions.go
+++ b/cip_definitions.go
@@ -6,13 +6,13 @@ import (
 	"io"
 )
 
-type cipAddress byte
+type CIPAddress byte
 
-func (p cipAddress) Bytes() []byte {
+func (p CIPAddress) Bytes() []byte {
 	return []byte{byte(p)}
 }
 
-func (p cipAddress) Len() int {
+func (p CIPAddress) Len() int {
 	return 0
 }
 

--- a/connect.go
+++ b/connect.go
@@ -114,7 +114,7 @@ func (client *Client) Connect() error {
 
 	// default path is back plane -> slot 0
 	if client.Controller.Path == nil {
-		client.Controller.Path, err = Serialize(CIPPort{PortNo: 1}, cipAddress(0))
+		client.Controller.Path, err = Serialize(CIPPort{PortNo: 1}, CIPAddress(0))
 		if err != nil {
 			msg := "cannot setup default path"
 			client.Logger.Error(msg, slog.Any("err", err))

--- a/examples/ReadPowerflexParam/main.go
+++ b/examples/ReadPowerflexParam/main.go
@@ -21,15 +21,17 @@ func main() {
 
 	defer c.Disconnect()
 
-	ParamNo := 44 // param 44 = maximum hertz * 100
-
-	path, err := gologix.Serialize(
-		gologix.CipObject_Parameter,
-		gologix.CIPInstance(ParamNo),
-		gologix.CIPAttribute(1),
-	)
-	if err != nil {
-		log.Printf("could not serialize path: %v", err)
+	//path, err := gologix.Serialize(
+	//gologix.CipObject_Parameter,
+	//gologix.CIPInstance(ParamNo),
+	//gologix.CIPAttribute(1),
+	//)
+	path := (&gologix.PathBuilder{}).
+		Class(gologix.CipObject_Parameter).
+		Instance(44). // param 44 = maximum hertz * 100
+		Attribute(1)
+	if path.Err != nil {
+		log.Printf("could not serialize path: %v", path.Err)
 		return
 	}
 
@@ -45,10 +47,10 @@ func main() {
 		log.Fatalf("Failed to parse response: %v", err)
 	}
 	maxhz := float64(val) / 100
-	fmt.Printf("Parameter %d: %3.2f\n", ParamNo, maxhz)
+	fmt.Printf("Parameter 44: %3.2f\n", maxhz)
 
 	// you can also read multiple parameters at once using the GetAttributeList service
-	path, err = gologix.Serialize(gologix.CipObject_DPIParams, gologix.CIPInstance(0))
+	path2, err := gologix.Serialize(gologix.CipObject_DPIParams, gologix.CIPInstance(0))
 	if err != nil {
 		log.Printf("could not serialize path: %v", err)
 		return
@@ -71,7 +73,7 @@ func main() {
 		return
 	}
 
-	r, err := c.GenericCIPMessage(gologix.CIPService_ScatteredRead, path.Bytes(), params.Bytes())
+	r, err := c.GenericCIPMessage(gologix.CIPService_ScatteredRead, path2.Bytes(), params.Bytes())
 
 	if err != nil {
 		log.Fatalf("Failed to read parameters: %v", err)

--- a/path.go
+++ b/path.go
@@ -4,6 +4,7 @@ package gologix
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
@@ -97,4 +98,185 @@ func ParsePath(path string) (*bytes.Buffer, error) {
 	}
 
 	return bytes.NewBuffer(byte_path), nil
+}
+
+// PathBuilder constructs a CIP path incrementally using a fluent builder pattern.
+// Each method appends one logical segment to the path and returns the same *PathBuilder,
+// so calls can be chained:
+//
+//	path := new(gologix.PathBuilder).
+//	    Class(gologix.CIPClass_MessageRouter).
+//	    Instance(1).
+//	    Bytes()
+//
+// If any method encounters an error the builder stores it in Err and all subsequent
+// method calls become no-ops, so you only need to check Err once at the end.
+type PathBuilder struct {
+	b bytes.Buffer
+	// Err holds the first error encountered while building the path.
+	// All methods check this field before writing; once set, further calls are no-ops.
+	Err error
+}
+
+// NewPathBuilder creates and returns a new PathBuilder with an empty path and no error.
+// You could also just do a PathBuilder{} but if trying to use it directly you would need to make it a pointer like
+// &(PathBuilder{}) to be able to chain methods, so this is a little more convenient.
+func NewPathBuilder() *PathBuilder {
+	return &PathBuilder{}
+}
+
+// Custom appends raw bytes directly to the path without any interpretation.
+// This is useful when you need to include a pre-encoded segment that has no
+// dedicated builder method.
+func (pb *PathBuilder) Custom(data []byte) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	_, err := pb.b.Write(data)
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing segment %v: %w", data, err)
+	}
+	return pb
+
+}
+
+// Bytes returns the accumulated path as a raw byte slice.
+// Check Err before using the returned slice to confirm no error occurred during construction.
+func (pb *PathBuilder) Bytes() []byte {
+	return pb.b.Bytes()
+}
+
+// Class appends a logical class segment for the given CIPClass to the path.
+// Class segments identify the object class being addressed (e.g. the Message Router class).
+// There are a number of predefined classes in the gologix package.
+// If using a constant, there is no need to cast it to CIPClass, e.g. Class(4) is fine.
+// If using a variable, you will have to cast it to CIPClass, e.g. Class(gologix.CipClass(myVar)).
+func (pb *PathBuilder) Class(classID CIPClass) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	_, err := pb.b.Write(classID.Bytes())
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing class ID %v: %w", classID, err)
+	}
+	return pb
+}
+
+// Instance appends a logical instance segment for the given CIPInstance to the path.
+// Instance segments select a specific instance of the class identified by the preceding Class segment.
+// If using a constant, there is no need to cast it to CIPInstance, e.g. Instance(1) is fine.
+// If using a variable, you will have to cast it to CIPInstance, e.g. Instance(gologix.CipInstance(myVar)).
+func (pb *PathBuilder) Instance(instanceID CIPInstance) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	_, err := pb.b.Write(instanceID.Bytes())
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing instance ID %v: %w", instanceID, err)
+	}
+	return pb
+}
+
+// Attribute appends a logical attribute segment for the given CIPAttribute to the path.
+// Attribute segments target a specific attribute within an object instance.
+// If using a constant, there is no need to cast it to CIPAttribute, e.g. Attribute(1) is fine.
+// If using a variable, you will have to cast it to CIPAttribute, e.g. Attribute(gologix.CipAttribute(myVar)).
+func (pb *PathBuilder) Attribute(attributeID CIPAttribute) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	_, err := pb.b.Write(attributeID.Bytes())
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing attribute ID %v: %w", attributeID, err)
+	}
+	return pb
+}
+
+// Symbolic appends an ANSI extended symbolic segment for the given tag or symbol name.
+// This is the standard way to address a named controller tag, e.g. "MyTag" or "Program:MyProg.MyTag".
+// If a tag has nested paths (such as a member of a struct) you need to add a separate symbolic segment
+// for each level of the path, e.g. "MyProg.MyTag.MyField" becomes Symbolic("MyProg").Symbolic("MyTag").Symbolic("MyField").
+func (pb *PathBuilder) Symbolic(symbol string) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	str, err := marshalIOIPart(symbol)
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing symbolic ID %v: %w", symbol, err)
+	}
+	pb.b.Write(str)
+	return pb
+}
+
+// Element appends a logical element segment for the given CIPElement index.
+// Element segments address a specific element within an array tag.
+// Used for accessing array elements, e.g. MyArray[3] would be Symbolic("MyArray").Element(3).
+func (pb *PathBuilder) Element(elementID CIPElement) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	_, err := pb.b.Write(elementID.Bytes())
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing element ID %v: %w", elementID, err)
+	}
+	return pb
+}
+
+// Port appends a port segment with the given port number.
+// Port segments route the message through a specific communication port on the device.
+// Use together with Address to hop across network boundaries (e.g. through a ControlLogix backplane).
+func (pb *PathBuilder) Port(portNo byte) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	err := binary.Write(&(pb.b), binary.LittleEndian, portNo)
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing port number %v: %w", portNo, err)
+	}
+	return pb
+}
+
+// Address appends a link-address segment for the given CIPAddress (node address).
+// This is typically used after a Port segment to specify the destination node on that port.
+func (pb *PathBuilder) Address(address CIPAddress) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	_, err := pb.b.Write(address.Bytes())
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing address %v: %w", address, err)
+	}
+	return pb
+}
+
+// Slot appends a backplane slot number to the path.
+// This is a shorthand for the common case of routing to a module in a specific chassis slot
+// (e.g. slot 0 for the first module in a ControlLogix rack).
+func (pb *PathBuilder) Slot(slotNo uint8) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	err := binary.Write(&(pb.b), binary.LittleEndian, slotNo)
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing address %v: %w", slotNo, err)
+	}
+	return pb
+}
+
+// Parse parses a human-readable path string in the same format a msg instruction uses in logix (e.g. "0,1,192.168.2.1,0,1")
+// The resulting bytes are appended to the path being built.
+func (pb *PathBuilder) Parse(path string) *PathBuilder {
+	if pb.Err != nil {
+		return pb
+	}
+	buf, err := ParsePath(path)
+	if err != nil {
+		pb.Err = fmt.Errorf("error parsing path %v: %w", path, err)
+		return pb
+	}
+	_, err = pb.b.Write(buf.Bytes())
+	if err != nil {
+		pb.Err = fmt.Errorf("error writing parsed path %v: %w", path, err)
+	}
+	return pb
 }

--- a/path_test.go
+++ b/path_test.go
@@ -74,7 +74,7 @@ func TestPathBuild(t *testing.T) {
 		},
 		{
 			name: "backplane to slot 0",
-			path: []any{CIPPort{PortNo: 1}, cipAddress(0)},
+			path: []any{CIPPort{PortNo: 1}, CIPAddress(0)},
 			want: []byte{0x01, 0x00},
 		},
 		{
@@ -107,6 +107,59 @@ func TestPathBuild(t *testing.T) {
 			}
 			if !check_bytes(have.Bytes(), tt.want) {
 				t.Errorf("ResultMismatch.\n Have %v\n Want %v\n", have.Bytes(), tt.want)
+			}
+		})
+	}
+
+}
+
+func TestPathBuilder(t *testing.T) {
+
+	tests := []struct {
+		name string
+		path *PathBuilder
+		want []byte
+	}{
+		{
+			name: "connection manager only",
+			path: (&PathBuilder{}).Class(CipObject_ConnectionManager),
+			want: []byte{0x20, 0x06},
+		},
+		{
+			name: "backplane to slot 0",
+			path: (&PathBuilder{}).Port(1).Slot(0),
+			want: []byte{0x01, 0x00},
+		},
+		{
+			name: "connection manager instance 1",
+			path: (&PathBuilder{}).Class(CipObject_ConnectionManager).Instance(1),
+			want: []byte{0x20, 0x06, 0x24, 0x01},
+		},
+		{
+			name: "Symbol Object Instance 0",
+			path: (&PathBuilder{}).Class(CipObject_Symbol).Instance(0),
+			want: []byte{0x20, 0x6B, 0x24, 0x00},
+		},
+		{
+			name: "Symbol Object Instance 0 of tag 'Program:MainProgram'",
+			path: (&PathBuilder{}).Symbolic("program:mainprogram").Class(CipObject_Symbol).Instance(0),
+			want: []byte{0x91, 0x13, 0x70, 0x72, 0x6f, 0x67, 0x72, 0x61, 0x6d, 0x3a, 0x6d, 0x61, 0x69,
+				0x6e, 0x70, 0x72, 0x6f, 0x67, 0x72, 0x61, 0x6d, 0x00, 0x20, 0x6B, 0x24, 0x00},
+		},
+		{
+			name: "Template Attributes Instance 0x02E9",
+			path: (&PathBuilder{}).Class(CipObject_Template).Instance(0x02E9),
+			want: []byte{0x20, 0x6C, 0x25, 0x00, 0xE9, 0x02},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := tt.path
+			if pb.Err != nil {
+				t.Errorf("Problem building path. %v", pb.Err)
+			}
+			if !check_bytes(pb.Bytes(), tt.want) {
+				t.Errorf("ResultMismatch.\n Have %v\n Want %v\n", pb.Bytes(), tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request introduces a new `PathBuilder` type to the codebase, providing a more flexible and fluent way to construct CIP paths. It also updates existing code and tests to use the new `CIPAddress` type and the builder pattern where appropriate. The main goal is to simplify path construction, improve readability, and reduce the likelihood of errors when building paths for CIP messages.

Key changes include:

**New PathBuilder API:**

* Added the `PathBuilder` struct in `path.go`, with chainable methods like `Class`, `Instance`, `Attribute`, `Symbolic`, `Element`, `Port`, `Address`, `Slot`, and `Parse`, as well as error handling and a `Bytes()` method to retrieve the final path. This enables building complex CIP paths in a more readable and maintainable way.
* Added comprehensive documentation for each method in `PathBuilder`, explaining usage and behavior.

**Refactoring to use PathBuilder and CIPAddress:**

* Updated the `examples/ReadPowerflexParam/main.go` example to use the new `PathBuilder` API for path construction, replacing the previous `Serialize` calls with chained builder methods. [[1]](diffhunk://#diff-c9cc6bce2707bd0a93a02734e3545ef3b0ce200f5caed3799ddb7bf311da8846L24-R34) [[2]](diffhunk://#diff-c9cc6bce2707bd0a93a02734e3545ef3b0ce200f5caed3799ddb7bf311da8846L48-R53) [[3]](diffhunk://#diff-c9cc6bce2707bd0a93a02734e3545ef3b0ce200f5caed3799ddb7bf311da8846L74-R76)
* Changed all uses of the old `cipAddress` type to the new `CIPAddress` type throughout the codebase, including in `cip_definitions.go`, `connect.go`, and tests, to ensure consistency and clarity. [[1]](diffhunk://#diff-b5864c0c3f967bb400eb292303a07e1823fe92a6e3ea3e52a4ba3f7b193bd2aeL9-R15) [[2]](diffhunk://#diff-82f6a0eb10c47bc6590f594adc997b5a12de370dfd735a05c44cf8ff6fbf7a12L117-R117) [[3]](diffhunk://#diff-e65edbcd5a006378e11ec33d7b121f21a20ec2631433f0b75bfa54e11768e9caL77-R77)

**Testing enhancements:**

* Added a new `TestPathBuilder` unit test in `path_test.go` to verify correct behavior of the builder for various path scenarios, improving test coverage and reliability.

**Other improvements:**

* Imported `encoding/binary` in `path.go` to support binary writing in the new builder methods.