### PR TITLE
fix(write): support []string in CIPItem.Serialize

### DIFF
--- a/items.go
+++ b/items.go
@@ -231,6 +231,41 @@ func (item *CIPItem) Serialize(strs ...any) error {
 				return fmt.Errorf("problem writing string payload: %v", err)
 			}
 
+		case []string:
+			// Each STRING element on the wire is a fixed 88-byte slot:
+			// 4-byte LEN (uint32) + 84-byte data buffer, the same layout
+			// the controller emits when reading a STRING array.
+			//
+			// Empty or nil slice contributes zero bytes for this argument.
+			// continue keeps the outer variadic loop processing any
+			// remaining arguments instead of returning early.
+			if len(x) == 0 {
+				continue
+			}
+			for _, s := range x {
+				// Clamp the LEN header to the 84-byte payload so the
+				// receiver never sees a header claiming more bytes than
+				// the slot actually carries. copy() below truncates the
+				// payload to 84 bytes; without clamping the header a
+				// >84-byte input would desync the receiver. This is
+				// stricter than the single-string case above, which
+				// writes the raw len(s) into the LEN header even when
+				// the payload gets truncated — out of scope to change
+				// here.
+				strLen := uint32(len(s))
+				if strLen > 84 {
+					strLen = 84
+				}
+				if err := binary.Write(item, binary.LittleEndian, strLen); err != nil {
+					return fmt.Errorf("problem writing string header: %v", err)
+				}
+				b := make([]byte, 84)
+				copy(b, s)
+				if err := binary.Write(item, binary.LittleEndian, b); err != nil {
+					return fmt.Errorf("problem writing string payload: %v", err)
+				}
+			}
+
 		case Serializable:
 			err := binary.Write(item, binary.LittleEndian, x.Bytes())
 			if err != nil {

--- a/items_test.go
+++ b/items_test.go
@@ -1,0 +1,83 @@
+package gologix
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestSerializeStringSliceEmpty verifies that an empty or nil []string
+// passed to CIPItem.Serialize is treated as a no-op: returns nil and
+// does not write any payload bytes. write_single declares elements=0
+// in the IOI footer for an empty slice, so emitting a partial slot
+// would desync the wire format and the controller would reject the
+// request with a confusing CIP status.
+func TestSerializeStringSliceEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+	}{
+		{name: "nil", in: nil},
+		{name: "empty", in: []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := CIPItem{}
+			if err := item.Serialize(tc.in); err != nil {
+				t.Fatalf("Serialize(%v) returned error: %v", tc.in, err)
+			}
+			if len(item.Data) != 0 {
+				t.Fatalf("Serialize(%v) wrote %d bytes; want 0", tc.in, len(item.Data))
+			}
+		})
+	}
+}
+
+// TestSerializeStringSliceShape verifies the wire shape for a non-empty
+// []string: each element occupies a fixed 88-byte slot (4-byte LEN +
+// 84-byte data buffer). N elements produce exactly N*88 bytes.
+// long-over-84 also asserts the LEN header is clamped to 84 so the
+// wire header never claims more bytes than the slot actually carries.
+func TestSerializeStringSliceShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		wantLen uint32
+	}{
+		{name: "single", in: []string{"hello"}, wantLen: 5},
+		{name: "multi", in: []string{"a", "bb", "ccc"}, wantLen: 1},
+		{name: "long-exact-84", in: []string{string(make([]byte, 84))}, wantLen: 84},
+		{name: "long-over-84", in: []string{string(make([]byte, 200))}, wantLen: 84},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := CIPItem{}
+			if err := item.Serialize(tc.in); err != nil {
+				t.Fatalf("Serialize(%v) returned error: %v", tc.in, err)
+			}
+			want := len(tc.in) * 88
+			if len(item.Data) != want {
+				t.Fatalf("Serialize(%v) wrote %d bytes; want %d", tc.in, len(item.Data), want)
+			}
+			// LEN header of the first element must match wantLen.
+			gotLen := binary.LittleEndian.Uint32(item.Data[0:4])
+			if gotLen != tc.wantLen {
+				t.Fatalf("first-element LEN header = %d; want %d", gotLen, tc.wantLen)
+			}
+		})
+	}
+}
+
+// TestSerializeStringSliceVariadicContinues verifies that an empty
+// []string sandwiched between other Serialize arguments does NOT
+// short-circuit the variadic loop: arguments before and after the
+// empty slice still get serialized.
+func TestSerializeStringSliceVariadicContinues(t *testing.T) {
+	item := CIPItem{}
+	if err := item.Serialize(uint32(0xDEADBEEF), []string{}, uint32(0xCAFEBABE)); err != nil {
+		t.Fatalf("Serialize(...) returned error: %v", err)
+	}
+	// Two uint32 values = 8 bytes. Empty []string contributes 0.
+	if len(item.Data) != 8 {
+		t.Fatalf("Serialize wrote %d bytes; want 8 (two uint32 with empty []string between)", len(item.Data))
+	}
+}

--- a/tests/write_test.go
+++ b/tests/write_test.go
@@ -1,6 +1,7 @@
 package gologix_tests
 
 import (
+	"fmt"
 	"log"
 	"testing"
 
@@ -376,6 +377,75 @@ func TestWriteUdt(t *testing.T) {
 				t.Errorf("success writing wrong udt: %v", err)
 			}
 
+		})
+	}
+}
+
+// bug: Write/WriteMulti/WriteMap with a []string field fail with
+//   binary.Write: some values are not fixed-sized in type []string
+// because items.Serialize had no case for []string and fell through
+// to binary.Write, which rejects slices of strings.
+// This test writes a []string then reads each element back via the
+// single-tag Read path (which already works) to verify the wire format.
+// The original ReadStrings values are restored element-by-element via
+// the scalar Write path so a regression in the new code can never
+// corrupt the L5X test data.
+func TestWriteStringArray(t *testing.T) {
+	tcs := getTestConfig()
+	for _, tc := range tcs.TagReadWriteTests {
+		t.Run(tc.PlcAddress, func(t *testing.T) {
+			client := gologix.NewClient(tc.PlcAddress)
+			err := client.Connect()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer func() {
+				err := client.Disconnect()
+				if err != nil {
+					t.Errorf("problem disconnecting. %v", err)
+				}
+			}()
+
+			const tag = "program:gologix_tests.ReadStrings"
+
+			// Step 1: backup current values via the working single-tag Read.
+			backup := make([]string, 10)
+			if err := client.Read(tag, backup); err != nil {
+				t.Fatalf("backup read failed: %v", err)
+			}
+
+			// Deferred cleanup (runs after Step 3 below): always restore
+			// originals one-by-one via the scalar write path, which is
+			// independent of the code under test so a regression in the
+			// new code cannot permanently corrupt the L5X dataset.
+			defer func() {
+				for i, v := range backup {
+					idxTag := fmt.Sprintf("%s[%d]", tag, i)
+					if werr := client.Write(idxTag, v); werr != nil {
+						t.Errorf("restore %s failed: %v", idxTag, werr)
+					}
+				}
+			}()
+
+			// Step 2: write a []string with mixed lengths so any per-element
+			// alignment bug surfaces immediately on the read-back.
+			want := []string{"x1", "yy2", "zzz3", "wwww4", "v5", "u66", "t777", "s8888", "r9", "q00"}
+			if err := client.Write(tag, want); err != nil {
+				t.Fatalf("Write([]string) failed: %v", err)
+			}
+
+			// Step 3: read back via the single-tag Read path (already
+			// supports arrays of strings) and verify each element matches.
+			got := make([]string, 10)
+			if err := client.Read(tag, got); err != nil {
+				t.Fatalf("read-back failed: %v", err)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("element %d: want %q got %q", i, want[i], got[i])
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes #62.

Writing a STRING array via `Write` / `WriteMulti` / `WriteMap` was failing with `binary.Write: some values are not fixed-sized in type []string`. `GoVarToCIPType` already registers `[]string` and `write_single` handles slices, but `CIPItem.Serialize` had a `case string` and no `case []string`, so it fell into `default` → `binary.Write(item, ..., []string)` which encoding/binary rejects.

The fix adds a `case []string` that loops the same per-element layout the controller emits when reading a STRING array: 4-byte LEN + 84-byte data buffer = 88 bytes per slot. A few details:

- Empty / nil slice → `continue` (no-op for that argument). Using `return nil` here would silently drop any remaining variadic args after the empty slice, which I caught in review.
- LEN header is clamped to 84 so the receiver never sees a header that claims more bytes than the slot carries. The existing `case string:` writes the raw `len(s)` even when the payload is truncated — left alone here on purpose to keep this PR focused.

### Tests

Hardware: ran against a 1769-L24ER with the standard `gologix_tests` program. New `TestWriteStringArray` backs up `program:gologix_tests.ReadStrings`, writes a `[]string` with mixed lengths, reads each element back via the existing scalar `Read`, asserts equality, and restores the original values element-by-element through the scalar `Write` path so a regression in this code can't permanently corrupt the L5X dataset.

```
=== RUN   TestWriteStringArray
INFO Session connected
INFO successfully opened connection ConnectionSize=4000
INFO starting disconnection
INFO successfully disconnected from controller
--- PASS: TestWriteStringArray
```

Existing write suite (`TestWrite`, `TestMultiWrite`, `TestWriteUdt`, `TestWriteUdt1`) and the string read suite (`TestReadListWithString`, `TestReadListWithStringArray`, `TestReadWithStringArray`, `TestReadStringArray`) still pass — no read-side regression from sharing `items.go`.

Unit (no PLC, new `items_test.go`): covers empty/nil no-op, the per-element 88-byte shape (single / multi / exactly-84 / over-84-with-clamp-asserted), and the variadic-continues property (`Serialize(uint32, []string{}, uint32)` writes 8 bytes, not 4).

Before the fix:

```
Write([]string) failed: problem serializing value. problem writing default item: binary.Write: some values are not fixed-sized in type []string
```

Out of scope: pre-existing failures on master unrelated to this PR — `TestDataTableBuffer` hardcodes a different PLC IP, `TestGetAttrSingle/List` depend on zeroed identity fields in `test_config.json`, and `TestReadMultiNew/Map` hit the V20 ENBT `EmbeddedServiceError` you already noted on PR #60.