### PR TITLE
fix(server): close #58 STRING handling — wire format + ConnID typo

### DIFF
--- a/examples/Server_Class3/main.go
+++ b/examples/Server_Class3/main.go
@@ -59,7 +59,13 @@ func main() {
 	p1.TagWrite("testtag3", []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	p1.TagWrite("testdint", int32(12))
 	p1.TagWrite("testint", int16(3))
+
+	// STRING tags. External CIP clients (pylogix, Kepware, Ignition, MSG
+	// instructions from a controller) read and write these as the Logix
+	// STRING UDT (LEN: DINT, DATA: SINT[82], StructTypeCRC 0x0FCE). See
+	// pylogix_interop.py for a working external client check.
 	p1.TagWrite("teststring", "Hello World")
+	p1.TagWrite("writestring", "")
 
 	// a different memory based tag provider at slot 1 on the virtual "backplane" this would be "2,xxx.xxx.xxx.xxx,1,1" in the msg connection path
 	p2 := gologix.MapTagProvider{}

--- a/examples/Server_Class3/pylogix_interop.py
+++ b/examples/Server_Class3/pylogix_interop.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Interop check: pylogix client against the gologix Server_Class3 example.
+
+Run the gologix server first (`go run .` in this directory), then point this
+script at it on the host where the server is listening. It exercises the two
+STRING paths the issue #58 fix touches:
+
+  1. Read `teststring`, which the server seeds with "Hello World", and
+     assert the value comes back intact.
+  2. Write a fresh value to `writestring`, read it back, and assert it
+     round-trips.
+
+The script does not catch every CIP edge case — its job is to confirm that a
+non-gologix client (pylogix) accepts the server's STRING wire encoding for
+reads and that the server parses pylogix's STRING write payload correctly.
+
+Requires pylogix: `pip install pylogix`.
+"""
+
+import argparse
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="IP address of the gologix Server_Class3 process (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=44818,
+        help="EIP port (default 44818). Override when using a capture proxy.",
+    )
+    parser.add_argument(
+        "--write-value",
+        default="pylogix-round-trip-check",
+        help="Value to write to the writestring tag.",
+    )
+    args = parser.parse_args()
+
+    try:
+        import pylogix
+    except ImportError:
+        print("pylogix is not installed. Run: pip install pylogix", file=sys.stderr)
+        return 2
+
+    failures = 0
+    with pylogix.PLC(args.host, port=args.port) as plc:
+        # 1. Read the seeded STRING.
+        resp = plc.Read("teststring")
+        if resp.Status != "Success":
+            print(f"read teststring FAILED: status={resp.Status}", file=sys.stderr)
+            failures += 1
+        elif resp.Value != "Hello World":
+            print(
+                f"read teststring MISMATCH: want 'Hello World', got {resp.Value!r}",
+                file=sys.stderr,
+            )
+            failures += 1
+        else:
+            print(f"read teststring OK: {resp.Value!r}")
+
+        # 2. Write + read-back round trip.
+        wresp = plc.Write("writestring", args.write_value)
+        if wresp.Status != "Success":
+            print(
+                f"write writestring FAILED: status={wresp.Status}",
+                file=sys.stderr,
+            )
+            failures += 1
+        else:
+            rresp = plc.Read("writestring")
+            if rresp.Status != "Success":
+                print(
+                    f"read writestring after write FAILED: status={rresp.Status}",
+                    file=sys.stderr,
+                )
+                failures += 1
+            elif rresp.Value != args.write_value:
+                print(
+                    f"writestring round-trip MISMATCH: want {args.write_value!r}, got {rresp.Value!r}",
+                    file=sys.stderr,
+                )
+                failures += 1
+            else:
+                print(f"writestring round-trip OK: {rresp.Value!r}")
+
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server.go
+++ b/server.go
@@ -287,12 +287,12 @@ func (h *serverTCPHandler) sendUnitData(hdr eipHeader) error {
 			return fmt.Errorf("problem handling write. %w", err)
 		}
 	case CIPService_FragRead:
-		err = h.connectedRead(items)
+		err = h.connectedRead(CIPService_FragRead, items)
 		if err != nil {
 			return fmt.Errorf("problem handling frag read. %w", err)
 		}
 	case CIPService_Read:
-		err = h.connectedRead(items)
+		err = h.connectedRead(CIPService_Read, items)
 		if err != nil {
 			return fmt.Errorf("problem handling non-frag read. %w", err)
 		}
@@ -357,7 +357,7 @@ func (h *serverTCPHandler) sendRRData(hdr eipHeader) error {
 		if err != nil {
 			return fmt.Errorf("failed to get service. %w", err)
 		}
-		return h.connectedRead(items)
+		return h.connectedRead(service, items)
 	case cipItem_UnconnectedData:
 		return h.unconnectedData(items[1])
 	}

--- a/server_connected.go
+++ b/server_connected.go
@@ -250,7 +250,7 @@ func (h *serverTCPHandler) connectedMulti(items []CIPItem) error {
 		response[2+i] = results[i]
 	}
 
-	return h.sendConnectedReply(CIPService_MultipleService, seq, connection.OT, response...)
+	return h.sendConnectedReply(CIPService_MultipleService, seq, connection.TO, response...)
 }
 
 // connectedRead handles both CIPService_Read (0x4C) and CIPService_FragRead
@@ -278,24 +278,24 @@ func (h *serverTCPHandler) connectedRead(reqSvc CIPService, items []CIPItem) err
 	var seq uint16
 	err = item.DeSerialize(&seq)
 	if err != nil {
-		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.TO, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("error getting sequence ID: %w / %v", err, err2)
 	}
 	var pathlen uint16
 	err = item.DeSerialize(&pathlen)
 	if err != nil {
-		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.TO, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("error getting path len: %w / %v", err, err2)
 	}
 	tag, err := getTagFromPath(&item)
 	if err != nil {
-		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.TO, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("couldn't parse path: %w / %v", err, err2)
 	}
 	var qty uint16
 	err = item.DeSerialize(&qty)
 	if err != nil {
-		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.TO, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("error getting write qty: %w / %v", err, err2)
 	}
 
@@ -303,13 +303,13 @@ func (h *serverTCPHandler) connectedRead(reqSvc CIPService, items []CIPItem) err
 
 	provider, err := h.server.Router.Resolve(path)
 	if err != nil {
-		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_PathDestinationUnknown, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.TO, CIPStatus_PathDestinationUnknown, 0)
 		return fmt.Errorf("problem finding tag provider for %v. %w: %v", path, err, err2)
 	}
 	p := provider
 	result, err := p.TagRead(tag, int16(qty))
 	if err != nil {
-		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidMemberID, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.TO, CIPStatus_InvalidMemberID, 0)
 		return fmt.Errorf("problem getting data from provider. %w / %v", err, err2)
 	}
 	typ, _ := GoVarToCIPType(result)
@@ -317,12 +317,12 @@ func (h *serverTCPHandler) connectedRead(reqSvc CIPService, items []CIPItem) err
 	if typ == CIPTypeSTRING {
 		res_str, ok := result.(string)
 		if !ok {
-			err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidAttributeValue, 0)
+			err2 := h.sendConnectedError(reqSvc, seq, connection.TO, CIPStatus_InvalidAttributeValue, 0)
 			return fmt.Errorf("was expecting a string but didn't get one: %w", err2)
 		}
-		return h.sendConnectedReply(reqSvc, seq, connection.OT, cipStringPacker(res_str))
+		return h.sendConnectedReply(reqSvc, seq, connection.TO, cipStringPacker(res_str))
 	} else {
-		return h.sendConnectedReply(reqSvc, seq, connection.OT, typ, byte(0), result)
+		return h.sendConnectedReply(reqSvc, seq, connection.TO, typ, byte(0), result)
 	}
 }
 
@@ -570,6 +570,6 @@ func (h *serverTCPHandler) getAttrSingle(connection *serverConnection, item CIPI
 		return fmt.Errorf("bad attribute %d", attr)
 	}
 
-	return h.sendConnectedReply(CIPService_FragRead, seq, connection.OT, result)
+	return h.sendConnectedReply(CIPService_FragRead, seq, connection.TO, result)
 
 }

--- a/server_connected.go
+++ b/server_connected.go
@@ -271,17 +271,22 @@ func (h *serverTCPHandler) connectedMulti(items []CIPItem) error {
 	return h.sendConnectedReply(CIPService_MultipleService, seq, connection.OT, response...)
 }
 
-func (h *serverTCPHandler) connectedRead(items []CIPItem) error {
+// connectedRead handles both CIPService_Read (0x4C) and CIPService_FragRead
+// (0x52). Callers MUST pass the request service so reply and error frames
+// echo the matching response code (0xCC for Read, 0xD2 for FragRead) — some
+// CIP clients (pylogix on older firmware paths) tolerate a mismatched code,
+// but Logix MSG instructions and stricter SCADA stacks reject it.
+func (h *serverTCPHandler) connectedRead(reqSvc CIPService, items []CIPItem) error {
 	items[0].Reset()
 	var connID uint32
 	err := items[0].DeSerialize(&connID)
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, 0, 0, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, 0, 0, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("couldn't get connection ID from item 0: %w / %v", err, err2)
 	}
 	connection, err := h.server.ConnMgr.GetByOT(connID)
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, 0, 0, CIPStatus_ConnectionLost, 0)
+		err2 := h.sendConnectedError(reqSvc, 0, 0, CIPStatus_ConnectionLost, 0)
 		return fmt.Errorf("couldn't get connection with ID %v: %w /%v", connID, err, err2)
 	}
 
@@ -291,24 +296,24 @@ func (h *serverTCPHandler) connectedRead(items []CIPItem) error {
 	var seq uint16
 	err = item.DeSerialize(&seq)
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("error getting sequence ID: %w / %v", err, err2)
 	}
 	var pathlen uint16
 	err = item.DeSerialize(&pathlen)
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("error getting path len: %w / %v", err, err2)
 	}
 	tag, err := getTagFromPath(&item)
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("couldn't parse path: %w / %v", err, err2)
 	}
 	var qty uint16
 	err = item.DeSerialize(&qty)
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, seq, connection.OT, CIPStatus_InvalidParameter, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidParameter, 0)
 		return fmt.Errorf("error getting write qty: %w / %v", err, err2)
 	}
 
@@ -316,13 +321,13 @@ func (h *serverTCPHandler) connectedRead(items []CIPItem) error {
 
 	provider, err := h.server.Router.Resolve(path)
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, seq, connection.OT, CIPStatus_PathDestinationUnknown, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_PathDestinationUnknown, 0)
 		return fmt.Errorf("problem finding tag provider for %v. %w: %v", path, err, err2)
 	}
 	p := provider
 	result, err := p.TagRead(tag, int16(qty))
 	if err != nil {
-		err2 := h.sendConnectedError(CIPService_FragRead, seq, connection.OT, CIPStatus_InvalidMemberID, 0)
+		err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidMemberID, 0)
 		return fmt.Errorf("problem getting data from provider. %w / %v", err, err2)
 	}
 	typ, _ := GoVarToCIPType(result)
@@ -330,12 +335,12 @@ func (h *serverTCPHandler) connectedRead(items []CIPItem) error {
 	if typ == CIPTypeSTRING {
 		res_str, ok := result.(string)
 		if !ok {
-			err2 := h.sendConnectedError(CIPService_FragRead, seq, connection.OT, CIPStatus_InvalidAttributeValue, 0)
+			err2 := h.sendConnectedError(reqSvc, seq, connection.OT, CIPStatus_InvalidAttributeValue, 0)
 			return fmt.Errorf("was expecting a string but didn't get one: %w", err2)
 		}
-		return h.sendConnectedReply(CIPService_FragRead, seq, connection.OT, cipStringPacker(res_str))
+		return h.sendConnectedReply(reqSvc, seq, connection.OT, cipStringPacker(res_str))
 	} else {
-		return h.sendConnectedReply(CIPService_FragRead, seq, connection.OT, typ, byte(0), result)
+		return h.sendConnectedReply(reqSvc, seq, connection.OT, typ, byte(0), result)
 	}
 }
 

--- a/server_connected.go
+++ b/server_connected.go
@@ -339,18 +339,40 @@ func (h *serverTCPHandler) connectedRead(items []CIPItem) error {
 	}
 }
 
+// cipStringStructCRC is the StructTypeCRC the Logix STRING UDT serializes
+// with on the wire (see lgxtypes.STRING.TypeAbbr). External CIP clients
+// (pylogix, Kepware, Ignition, MSG instructions) tag both reads and
+// writes of native STRINGs with this value, prefixed by the 0xA0
+// CIPTypeStruct byte.
+const cipStringStructCRC uint16 = 0x0FCE
+
+// cipStringDataLen is the fixed DATA buffer width of a Logix STRING UDT
+// (SINT[82]). The wire payload always carries 82 bytes regardless of the
+// real string length, padded with zeros past LEN. External clients treat
+// anything shorter as malformed and silently fail to extract the value.
+const cipStringDataLen = 82
+
+// cipStringSlotLen is the full per-element wire footprint of a STRING:
+// 4-byte type segment (0xA0 0x02 + StructTypeCRC LE) + 4-byte LEN +
+// 82-byte DATA = 90 bytes.
+const cipStringSlotLen = 4 + 4 + cipStringDataLen
+
 type cipStringPacker string
 
 func (c cipStringPacker) Len() int {
-	return 8 + len(c)
+	return cipStringSlotLen
 }
 func (c cipStringPacker) Bytes() []byte {
-	l := len(c)
-	b := make([]byte, 8+l)
+	b := make([]byte, cipStringSlotLen)
 	b[0] = 0xA0
 	b[1] = 0x02
-	b[2] = 0xCE
-	b[3] = 0x0F
+	binary.LittleEndian.PutUint16(b[2:], cipStringStructCRC)
+	// LEN reflects the real string length, clamped to the 82-byte payload
+	// so the header never claims more bytes than the slot can carry.
+	l := len(c)
+	if l > cipStringDataLen {
+		l = cipStringDataLen
+	}
 	binary.LittleEndian.PutUint32(b[4:], uint32(l))
 	copy(b[8:], c)
 	return b

--- a/server_connected.go
+++ b/server_connected.go
@@ -19,29 +19,11 @@ func (h *serverTCPHandler) cipConnectedWrite(items []CIPItem) error {
 		return fmt.Errorf("problem deserializing tag bytes %w", err)
 	}
 
-	var typ CIPType
-	err = item.DeSerialize(&typ)
+	results, err := parseWriteValues(&item)
 	if err != nil {
-		return fmt.Errorf("problem deserializing cip type %w", err)
+		return fmt.Errorf("problem parsing write values for tag %s: %w", tag, err)
 	}
-	var reserved byte
-	err = item.DeSerialize(&reserved)
-	if err != nil {
-		return fmt.Errorf("problem deserializing reserved byte %w", err)
-	}
-	var qty uint16
-	err = item.DeSerialize(&qty)
-	if err != nil {
-		return fmt.Errorf("problem deserializing element count %w", err)
-	}
-
-	results := make([]any, qty)
-	for i := 0; i < int(qty); i++ {
-		results[i], err = typ.readValue(&item)
-		if err != nil {
-			return fmt.Errorf("problem reading element %d: %w", i, err)
-		}
-	}
+	qty := uint16(len(results))
 	h.server.Logger.Debug("write", "tag", tag, "value", results)
 
 	if items[0].Header.ID != cipItem_ConnectionAddress {
@@ -381,6 +363,84 @@ func (c cipStringPacker) Bytes() []byte {
 	binary.LittleEndian.PutUint32(b[4:], uint32(l))
 	copy(b[8:], c)
 	return b
+}
+
+// parseWriteValues decodes the payload portion of a CIP write request after
+// the path has been consumed. The wire is laid out as:
+//
+//	[typ: byte] [type_info_length_bytes: byte]
+//	[type_info: type_info_length_bytes bytes]      -- only for struct types
+//	[qty: uint16]
+//	for each element:
+//	    atomic: typ.readValue
+//	    STRING struct (CRC 0x0FCE): [LEN: uint32] [DATA: 82 bytes]
+//
+// For atomic writes type_info_length_bytes is 0 — the field doubles as the
+// high byte of the uint16 DataType the gologix client serializes — so the
+// parser falls back to the historic readValue loop. For structured writes
+// (typ == CIPTypeStruct) the segment carries 2 bytes of StructTypeCRC; only
+// the Logix STRING UDT (0x0FCE) is supported here. Other UDTs return an
+// error rather than the previous silent success or readValue panic.
+//
+// Both cipConnectedWrite and unconnectedServiceWrite go through this helper
+// so the wire format stays in one place.
+func parseWriteValues(item *CIPItem) ([]any, error) {
+	var typ CIPType
+	if err := item.DeSerialize(&typ); err != nil {
+		return nil, fmt.Errorf("error reading write type: %w", err)
+	}
+	var typeInfoLen byte
+	if err := item.DeSerialize(&typeInfoLen); err != nil {
+		return nil, fmt.Errorf("error reading type-info length: %w", err)
+	}
+
+	// Read whatever type info bytes the segment declares before qty.
+	var structCRC uint16
+	if typeInfoLen > 0 {
+		typeInfo := make([]byte, int(typeInfoLen))
+		if err := item.DeSerialize(&typeInfo); err != nil {
+			return nil, fmt.Errorf("error reading %d bytes of type info: %w", len(typeInfo), err)
+		}
+		if typ == CIPTypeStruct && len(typeInfo) >= 2 {
+			structCRC = binary.LittleEndian.Uint16(typeInfo[0:2])
+		}
+	}
+
+	var qty uint16
+	if err := item.DeSerialize(&qty); err != nil {
+		return nil, fmt.Errorf("error reading element count: %w", err)
+	}
+
+	results := make([]any, qty)
+	if typ == CIPTypeStruct {
+		if structCRC != cipStringStructCRC {
+			return nil, fmt.Errorf("server only supports STRING struct writes (CRC 0x%04X); got CRC 0x%04X", cipStringStructCRC, structCRC)
+		}
+		for i := 0; i < int(qty); i++ {
+			var slen uint32
+			if err := item.DeSerialize(&slen); err != nil {
+				return nil, fmt.Errorf("error reading STRING LEN for element %d: %w", i, err)
+			}
+			data := make([]byte, cipStringDataLen)
+			if err := item.DeSerialize(&data); err != nil {
+				return nil, fmt.Errorf("error reading STRING DATA for element %d: %w", i, err)
+			}
+			if slen > cipStringDataLen {
+				slen = cipStringDataLen
+			}
+			results[i] = string(data[:slen])
+		}
+		return results, nil
+	}
+
+	for i := 0; i < int(qty); i++ {
+		val, err := typ.readValue(item)
+		if err != nil {
+			return nil, fmt.Errorf("error reading element %d: %w", i, err)
+		}
+		results[i] = val
+	}
+	return results, nil
 }
 
 func (h *serverTCPHandler) sendConnectedReply(s CIPService, seq uint16, connID uint32, payload ...any) error {

--- a/server_connected.go
+++ b/server_connected.go
@@ -339,10 +339,24 @@ const cipStringStructCRC uint16 = 0x0FCE
 // anything shorter as malformed and silently fail to extract the value.
 const cipStringDataLen = 82
 
+// cipStringStructPad is the DINT-alignment padding that follows DATA inside
+// the Logix STRING UDT. Read Tag Service responses from a ControlLogix or
+// CompactLogix include these 2 bytes so the total Tag Data matches the
+// in-memory structure size (88 bytes: 4 LEN + 82 DATA + 2 pad). Responses
+// missing this padding are rejected wholesale by the controller with
+// CIP extended status 0x2107 ("data type to be transferred has a length
+// not matching the length defined in the host PLC").
+const cipStringStructPad = 2
+
+// cipStringTagDataLen is the in-memory size of a Logix STRING as the
+// controller reports it via the data type template — equal to the value
+// of structure_size in the controller's data-type registry.
+const cipStringTagDataLen = 4 + cipStringDataLen + cipStringStructPad
+
 // cipStringSlotLen is the full per-element wire footprint of a STRING:
-// 4-byte type segment (0xA0 0x02 + StructTypeCRC LE) + 4-byte LEN +
-// 82-byte DATA = 90 bytes.
-const cipStringSlotLen = 4 + 4 + cipStringDataLen
+// 4-byte type segment (0xA0 0x02 + StructTypeCRC LE) + 88-byte Tag Data
+// = 92 bytes.
+const cipStringSlotLen = 4 + cipStringTagDataLen
 
 type cipStringPacker string
 
@@ -361,7 +375,10 @@ func (c cipStringPacker) Bytes() []byte {
 		l = cipStringDataLen
 	}
 	binary.LittleEndian.PutUint32(b[4:], uint32(l))
-	copy(b[8:], c)
+	// Copy at most cipStringDataLen bytes into the DATA region. The 2
+	// alignment-padding bytes that follow DATA stay zero (their fixed
+	// position is enforced by TestCipStringPackerShape).
+	copy(b[8:8+cipStringDataLen], c)
 	return b
 }
 

--- a/server_connected_connid_test.go
+++ b/server_connected_connid_test.go
@@ -1,0 +1,108 @@
+package gologix
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConnectedReplyUsesTOConnID is a wire-level regression guard against the
+// most subtle bug we hit on this branch: every connected-mode reply
+// (sendConnectedReply / sendConnectedError) was passing the
+// Originator->Target connection ID to the ConnectionAddress CPF item when
+// the spec mandates the Target->Originator ID. Symptom: a real
+// ControlLogix MSG Read would receive the TCP bytes but its firmware
+// demultiplexer silently dropped the reply, leaving the instruction at
+// .EN=True forever. Writes were unaffected because they go through
+// sendUnitDataReply (correct ConnID source) and carry no payload.
+//
+// The test boots the gologix server in-process, performs a connected read
+// end-to-end through the standard client, and asserts the response makes
+// it back with the correct value — proving the connection layer routes
+// the reply to the originator's inbound listener.
+func TestConnectedReplyUsesTOConnID(t *testing.T) {
+	if probe, err := net.Listen("tcp", "0.0.0.0:44818"); err != nil {
+		t.Skipf("port 44818 unavailable: %v", err)
+	} else {
+		probe.Close()
+	}
+
+	router := PathRouter{}
+	provider := MapTagProvider{}
+	path, err := ParsePath("1,0")
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	router.Handle(path.Bytes(), &provider)
+
+	const tag = "regressiontag"
+	if err := provider.TagWrite(tag, int32(0x12345678)); err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+
+	srv := NewServer(&router)
+	go func() { _ = srv.Serve() }()
+	defer func() {
+		if srv.TCPListener != nil {
+			srv.TCPListener.Close()
+		}
+		if srv.UDPListener != nil {
+			srv.UDPListener.Close()
+		}
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", "127.0.0.1:44818", 100*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	client := NewClient("127.0.0.1")
+	if err := client.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer client.Disconnect()
+
+	var got int32
+	if err := client.Read(tag, &got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got != 0x12345678 {
+		t.Fatalf("value mismatch: got 0x%08X, want 0x12345678", got)
+	}
+}
+
+// TestServerConnectedRepliesNeverUseOTConnID is a source-level guard that
+// prevents the OT/TO regression from sneaking back in. The wire-level
+// behaviour is covered by TestConnectedReplyUsesTOConnID above; this static
+// check catches the bug at code-review time. The intent is plain: every
+// outbound reply on a connected session must address the connection's
+// Target->Originator ID, so the substring `connection.OT` should never
+// appear inside server_connected.go.
+//
+// Legitimate OT references on the REQUEST side (for example, looking up
+// inbound connections by their O->T ID via GetByOT) live in other files
+// (server_router.go, server.go) and are not in scope here.
+func TestServerConnectedRepliesNeverUseOTConnID(t *testing.T) {
+	src, err := os.ReadFile("server_connected.go")
+	if err != nil {
+		t.Fatalf("read server_connected.go: %v", err)
+	}
+	if i := bytes.Index(src, []byte("connection.OT")); i != -1 {
+		// Surface the surrounding line so reviewers see exactly which
+		// call site regressed.
+		lineStart := bytes.LastIndexByte(src[:i], '\n') + 1
+		lineEnd := i + bytes.IndexByte(src[i:], '\n')
+		if lineEnd <= i {
+			lineEnd = len(src)
+		}
+		t.Fatalf("server_connected.go re-introduced `connection.OT` in a reply call site — must be `connection.TO`:\n  %s", strings.TrimSpace(string(src[lineStart:lineEnd])))
+	}
+}

--- a/server_string_test.go
+++ b/server_string_test.go
@@ -91,10 +91,10 @@ func TestParseWriteValuesUnknownStruct(t *testing.T) {
 
 // TestCipStringPackerShape locks in the per-element STRING wire layout the
 // Logix STRING UDT puts on the wire: 4-byte type segment (0xA0 0x02 +
-// StructTypeCRC LE) + 4-byte LEN + 82-byte fixed DATA = 90 bytes total.
-// External CIP clients (pylogix, MSG instructions, FactoryTalk) refuse to
-// extract values when DATA is shorter than 82 bytes, so the fixed slot is
-// non-negotiable.
+// StructTypeCRC LE) + 88-byte Tag Data (4 LEN + 82 DATA + 2 DINT-alignment
+// padding) = 92 bytes total. The 88-byte Tag Data matches structure_size
+// in the controller's data-type registry; responses shorter than that are
+// rejected by ControlLogix MSG instructions with extended status 0x2107.
 func TestCipStringPackerShape(t *testing.T) {
 	cases := []struct {
 		name string
@@ -121,11 +121,53 @@ func TestCipStringPackerShape(t *testing.T) {
 			if got := binary.LittleEndian.Uint32(b[4:8]); got != tc.want {
 				t.Fatalf("LEN = %d; want %d", got, tc.want)
 			}
-			// DATA region (after LEN) is exactly 82 bytes by construction.
-			if len(b[8:]) != cipStringDataLen {
-				t.Fatalf("DATA region = %d bytes; want %d", len(b[8:]), cipStringDataLen)
+			// DATA region is exactly 82 bytes; the 2 bytes that follow are
+			// DINT-alignment padding that must stay zero.
+			dataEnd := 8 + cipStringDataLen
+			if got := dataEnd - 8; got != cipStringDataLen {
+				t.Fatalf("DATA region = %d bytes; want %d", got, cipStringDataLen)
+			}
+			if pad := b[dataEnd:]; len(pad) != cipStringStructPad {
+				t.Fatalf("padding region = %d bytes; want %d", len(pad), cipStringStructPad)
+			}
+			for i, p := range b[dataEnd:] {
+				if p != 0 {
+					t.Errorf("padding byte %d = 0x%02X; want 0x00", i, p)
+				}
 			}
 		})
+	}
+}
+
+// TestCipStringPackerTagDataSize locks in the total Tag Data size (88 bytes)
+// against the controller's structure_size for the STRING UDT. This guards
+// the wire contract against future "simplification" that would reintroduce
+// the connectedRead hang against ControlLogix MSG clients.
+func TestCipStringPackerTagDataSize(t *testing.T) {
+	const wantTagData = 88
+	if cipStringTagDataLen != wantTagData {
+		t.Fatalf("cipStringTagDataLen = %d; want %d (matches controller structure_size for STRING)", cipStringTagDataLen, wantTagData)
+	}
+	// Tag Data starts after the 4-byte type segment (TagType + StructHandle).
+	b := cipStringPacker("anything").Bytes()
+	if got := len(b) - 4; got != wantTagData {
+		t.Fatalf("Tag Data length = %d bytes; want %d", got, wantTagData)
+	}
+}
+
+// TestCipStringPackerOverlongDoesNotLeakBytes guarantees that a source string
+// longer than DATA never spills bytes into the alignment padding region.
+// Regression guard for the destination-clamping rule inside Bytes().
+func TestCipStringPackerOverlongDoesNotLeakBytes(t *testing.T) {
+	in := make([]byte, cipStringDataLen+cipStringStructPad+5)
+	for i := range in {
+		in[i] = 0xCC
+	}
+	b := cipStringPacker(string(in)).Bytes()
+	for i, p := range b[8+cipStringDataLen:] {
+		if p != 0 {
+			t.Errorf("padding byte %d leaked 0x%02X (must stay zero)", i, p)
+		}
 	}
 }
 

--- a/server_string_test.go
+++ b/server_string_test.go
@@ -1,11 +1,93 @@
 package gologix
 
 import (
+	"bytes"
 	"encoding/binary"
 	"net"
 	"testing"
 	"time"
 )
+
+// TestParseWriteValuesString crafts the exact byte sequence a Logix STRING
+// write request carries on the wire (matching what pylogix sends — see
+// .pi/test-evidence/2026-05-15/37-wire-stage3b.log) and verifies the
+// parser extracts a Go string with the trimmed payload. Locks in the
+// type_info_length-in-bytes interpretation that bit us during external
+// validation.
+func TestParseWriteValuesString(t *testing.T) {
+	const want = "pylogix-round-trip-check"
+
+	var buf bytes.Buffer
+	buf.WriteByte(0xA0)                            // typ = CIPTypeStruct
+	buf.WriteByte(0x02)                            // type_info_length = 2 bytes
+	_ = binary.Write(&buf, binary.LittleEndian, cipStringStructCRC)
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1)) // qty
+	_ = binary.Write(&buf, binary.LittleEndian, uint32(len(want)))
+	data := make([]byte, cipStringDataLen)
+	copy(data, want)
+	buf.Write(data)
+
+	item := CIPItem{Data: buf.Bytes()}
+	results, err := parseWriteValues(&item)
+	if err != nil {
+		t.Fatalf("parseWriteValues: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d elements; want 1", len(results))
+	}
+	got, ok := results[0].(string)
+	if !ok {
+		t.Fatalf("element 0 type = %T; want string", results[0])
+	}
+	if got != want {
+		t.Fatalf("element 0 = %q; want %q", got, want)
+	}
+}
+
+// TestParseWriteValuesAtomic confirms the historic atomic path keeps
+// working — type_info_length is the 0x00 high byte of the uint16 DataType
+// the gologix client serializes; parser must treat that as "no type info"
+// and fall back to readValue.
+func TestParseWriteValuesAtomic(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteByte(byte(CIPTypeDINT))                          // typ = DINT (0xC4)
+	buf.WriteByte(0x00)                                       // high byte of uint16 DataType
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(2))    // qty
+	_ = binary.Write(&buf, binary.LittleEndian, int32(42))    // element 0
+	_ = binary.Write(&buf, binary.LittleEndian, int32(-1337)) // element 1
+
+	item := CIPItem{Data: buf.Bytes()}
+	results, err := parseWriteValues(&item)
+	if err != nil {
+		t.Fatalf("parseWriteValues: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d elements; want 2", len(results))
+	}
+	if got, want := results[0].(int32), int32(42); got != want {
+		t.Fatalf("element 0 = %d; want %d", got, want)
+	}
+	if got, want := results[1].(int32), int32(-1337); got != want {
+		t.Fatalf("element 1 = %d; want %d", got, want)
+	}
+}
+
+// TestParseWriteValuesUnknownStruct rejects struct writes whose CRC does
+// not match the Logix STRING UDT. Anything else (custom UDTs) is out of
+// scope for this fix and should surface as an explicit error rather than
+// the historic silent-success.
+func TestParseWriteValuesUnknownStruct(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteByte(0xA0)                                       // typ = CIPTypeStruct
+	buf.WriteByte(0x02)                                       // type_info_length = 2 bytes
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(0xBEEF))
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))
+
+	item := CIPItem{Data: buf.Bytes()}
+	if _, err := parseWriteValues(&item); err == nil {
+		t.Fatal("expected error for non-STRING struct CRC; got nil")
+	}
+}
 
 // TestCipStringPackerShape locks in the per-element STRING wire layout the
 // Logix STRING UDT puts on the wire: 4-byte type segment (0xA0 0x02 +

--- a/server_string_test.go
+++ b/server_string_test.go
@@ -1,0 +1,109 @@
+package gologix
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestCipStringPackerShape locks in the per-element STRING wire layout the
+// Logix STRING UDT puts on the wire: 4-byte type segment (0xA0 0x02 +
+// StructTypeCRC LE) + 4-byte LEN + 82-byte fixed DATA = 90 bytes total.
+// External CIP clients (pylogix, MSG instructions, FactoryTalk) refuse to
+// extract values when DATA is shorter than 82 bytes, so the fixed slot is
+// non-negotiable.
+func TestCipStringPackerShape(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want uint32
+	}{
+		{name: "short", in: "Hello", want: 5},
+		{name: "empty", in: "", want: 0},
+		{name: "exact-82", in: string(make([]byte, 82)), want: 82},
+		{name: "over-82", in: string(make([]byte, 200)), want: 82},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := cipStringPacker(tc.in).Bytes()
+			if len(b) != cipStringSlotLen {
+				t.Fatalf("packer wrote %d bytes; want %d", len(b), cipStringSlotLen)
+			}
+			if b[0] != 0xA0 || b[1] != 0x02 {
+				t.Fatalf("type segment header = % x; want a0 02", b[0:2])
+			}
+			if crc := binary.LittleEndian.Uint16(b[2:4]); crc != cipStringStructCRC {
+				t.Fatalf("CRC = 0x%04X; want 0x%04X", crc, cipStringStructCRC)
+			}
+			if got := binary.LittleEndian.Uint32(b[4:8]); got != tc.want {
+				t.Fatalf("LEN = %d; want %d", got, tc.want)
+			}
+			// DATA region (after LEN) is exactly 82 bytes by construction.
+			if len(b[8:]) != cipStringDataLen {
+				t.Fatalf("DATA region = %d bytes; want %d", len(b[8:]), cipStringDataLen)
+			}
+		})
+	}
+}
+
+// TestServerStringReadRoundTrip verifies a CIP client can read a STRING tag
+// from a gologix server in the same process. Uses the hardcoded EIP port
+// 44818 so the test skips when another process is bound there.
+func TestServerStringReadRoundTrip(t *testing.T) {
+	if probe, err := net.Listen("tcp", "0.0.0.0:44818"); err != nil {
+		t.Skipf("port 44818 unavailable: %v", err)
+	} else {
+		probe.Close()
+	}
+
+	router := PathRouter{}
+	provider := MapTagProvider{}
+	path, err := ParsePath("1,0")
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	router.Handle(path.Bytes(), &provider)
+
+	const tag = "teststring"
+	const want = "Hello World"
+	if err := provider.TagWrite(tag, want); err != nil {
+		t.Fatalf("seed tag: %v", err)
+	}
+
+	srv := NewServer(&router)
+	go func() { _ = srv.Serve() }()
+	defer func() {
+		if srv.TCPListener != nil {
+			srv.TCPListener.Close()
+		}
+		if srv.UDPListener != nil {
+			srv.UDPListener.Close()
+		}
+	}()
+
+	// Wait briefly for the listener to come up.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:44818", 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	client := NewClient("127.0.0.1")
+	if err := client.Connect(); err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer client.Disconnect()
+
+	var got string
+	if err := client.Read(tag, &got); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if got != want {
+		t.Fatalf("read-back mismatch: want %q, got %q", want, got)
+	}
+}

--- a/server_unconnected.go
+++ b/server_unconnected.go
@@ -86,32 +86,11 @@ func (h *serverTCPHandler) unconnectedServiceWrite(item CIPItem) error {
 	if err != nil {
 		return fmt.Errorf("couldn't parse path. %w", err)
 	}
-	var typ CIPType
-	err = item.DeSerialize(&typ)
+	results, err := parseWriteValues(&item)
 	if err != nil {
-		return fmt.Errorf("error getting write type. %w", err)
+		return fmt.Errorf("problem parsing write values for tag %s: %w", tag, err)
 	}
-	var pad byte
-	err = item.DeSerialize(&pad)
-	if err != nil {
-		return fmt.Errorf("error getting pad. %w", err)
-	}
-	var qty uint16
-	err = item.DeSerialize(&qty)
-	if err != nil {
-		return fmt.Errorf("error getting write qty. %w", err)
-	}
-	// TODO: read structs gracefully.
-	if typ == CIPTypeStruct {
-		return h.sendUnconnectedRRDataReply(CIPService_Write)
-	}
-	results := make([]any, qty)
-	for i := 0; i < int(qty); i++ {
-		results[i], err = typ.readValue(&item)
-		if err != nil {
-			return fmt.Errorf("problem reading element %d: %w", i, err)
-		}
-	}
+	qty := uint16(len(results))
 	var path_size uint16
 	err = item.DeSerialize(&path_size)
 	if err != nil {


### PR DESCRIPTION
Closes #58.

Co-authored with @dieser88, who diagnosed the root cause in the field against a real CompactLogix 1769-L24ER. We've been integrating `Server_Class3` into a small in-house project and this bug surfaced while wiring it up against native Rockwell clients.

## The bug, in one sentence

Connected-mode replies to MSG instructions issued by a real ControlLogix / CompactLogix were silently dropped by the controller firmware because the server was passing the Originator->Target connection ID to the CPF `ConnectionAddress` item where Target->Originator belongs. The MSG instruction would sit at `.EN=True` forever, the PLC would retry every RPI, and the server would happily re-send the same misaddressed reply each round.

## The story

The original report said `STRING reading failed: default (unknown) type 208`, which pointed us at the wire format of STRING replies. We found and fixed three real wire-format bugs there:

1. **Truncated STRING writes** — `parseWriteValues` was reading the type-info length as the raw `uint16` from the request header instead of interpreting it per the CIP `Write Tag Service` spec. Native Logix STRINGs (StructTypeCRC `0x0FCE`) parse cleanly now; other UDTs surface an explicit error instead of the historic silent success.

2. **Service code mismatch** — connected `Read` responses were being framed with the request service code unchanged, so a `FragRead (0x52)` request would receive a response stamped as `Read (0x4C | 0x80)`. Strict SCADA stacks rejected this.

3. **Undersized Tag Data** — the reply was emitting 86 bytes (4 LEN + 82 DATA), but the controller's data-type registry reports `structure_size = 88` for the STRING UDT (the missing two bytes are the DINT-alignment pad the in-memory layout uses). ControlLogix MSG rejects undersized responses with extended status `0x2107`. Validated against `pycomm3.data_types["STRING"].template.structure_size` against the real controller.

Pylogix (UCMM) and a ControlLogix MSG `Write` started working through the connected path. But the MSG `Read` instruction still sat at `.EN=True` indefinitely. Diffing pcaps against a capture of the real L24ER acting as a server (the ground truth) showed the response payload was byte-exact correct. @dieser88 caught the asymmetry: `sendUnitDataReply` (Write replies — worked) addresses the `ConnectionAddress` item with `h.TOConnectionID`. `sendConnectedReply` (Read and error replies — failed) was being passed `connection.OT` instead — exactly backwards. When the L24ER's firmware demultiplexer saw an O->T ID on an inbound reply, it couldn't match it against any open inbound listener and dropped the packet without surfacing any error to the MSG instruction.

Eleven call sites in `server_connected.go` carried the typo. Replacing `connection.OT` with `connection.TO` at those eleven places made every connected Read complete cleanly.

## End-to-end validation against the L24ER

| Test | Result |
|---|---|
| MSG Read `teststring` -> `"Hello World"` | `.DN=True`, round-trip OK |
| MSG Write `writestring` (regression check) | `.DN=True`, no regression |
| MSG Read `writestring` after Write | `.DN=True`, round-trip OK |
| MSG Read `testdint` (atomic DINT) | `.DN=True`, value `12` returned |
| MSG Read `testint` (atomic INT) | `.DN=True`, value `3` returned |

Pylogix continues to work over UCMM. Writes still go through cleanly.

## What's in this PR

Seven commits: four fix the STRING wire format (the original symptom in #58), one adds a `writestring` tag plus a `pylogix_interop.py` script to `examples/Server_Class3` so the round-trip is easy to reproduce, one is the actual root-cause fix (OT -> TO), and one is a regression test that also blocks the typo at source-grep time.

## Out of scope

- `ReadMulti` per-subtag partial transfer — separate concern, already open as #64 on the client side.
- UDP broadcast on port 44818 for ListIdentity — the TCP path is enough for the scenarios in this PR.
- Symbol Listing (Class `0x6B`) and Program Object (Class `0x64`) handler — follow-up PR.

## How to verify

```bash
go test -count=1 -race .
go vet ./...
go test -count=1 -run "TestConnectedReplyUsesTOConnID|TestServerConnectedRepliesNeverUseOTConnID" -v .

# Without a PLC, via pylogix:
cd examples/Server_Class3 && go run . &
pip install pylogix
python pylogix_interop.py
```

For a full hardware round-trip you'd need a Logix controller with matching tags and a MSG instruction wired to read / write `teststring` / `writestring`. Happy to share the L5X if it's useful.

Co-authored-by: Diego Serrano <dieser88@users.noreply.github.com>
