### PR TITLE
feat(server): close #13 silent drops + complete Identity Object handlers

### DIFF
--- a/cip_definitions.go
+++ b/cip_definitions.go
@@ -61,6 +61,10 @@ func (p *CIPAttribute) Read(r io.Reader) error {
 		*p = CIPAttribute(val)
 		return nil
 	case cipAttribute_16bit:
+		_, err = io.CopyN(io.Discard, r, 1) // skip the padding byte
+		if err != nil {
+			return fmt.Errorf("error skipping attribute padding byte: %w", err)
+		}
 		err := binary.Read(r, binary.LittleEndian, p)
 		if err != nil {
 			return fmt.Errorf("error reading 16 bit attribute: %w", err)

--- a/cip_definitions.go
+++ b/cip_definitions.go
@@ -172,6 +172,10 @@ func (p *CIPInstance) Read(r io.Reader) error {
 		*p = CIPInstance(val)
 		return nil
 	case cipInstance_16bit:
+		_, err = io.CopyN(io.Discard, r, 1) // skip the padding byte
+		if err != nil {
+			return fmt.Errorf("error skipping instance padding byte: %w", err)
+		}
 		var val uint16
 		err = binary.Read(r, binary.LittleEndian, &val)
 		if err != nil {
@@ -180,6 +184,10 @@ func (p *CIPInstance) Read(r io.Reader) error {
 		*p = CIPInstance(val)
 		return nil
 	case cipInstance_32bit:
+		_, err = io.CopyN(io.Discard, r, 1) // skip the padding byte
+		if err != nil {
+			return fmt.Errorf("error skipping instance padding byte: %w", err)
+		}
 		err = binary.Read(r, binary.LittleEndian, p)
 		if err != nil {
 			return fmt.Errorf("error reading 32 bit instance: %w", err)
@@ -247,6 +255,10 @@ func (p *CIPClass) Read(r io.Reader) error {
 		*p = CIPClass(val)
 		return nil
 	case cipClass_16bit:
+		_, err = io.CopyN(io.Discard, r, 1) // skip the padding byte
+		if err != nil {
+			return fmt.Errorf("error skipping class padding byte: %w", err)
+		}
 		err = binary.Read(r, binary.LittleEndian, p)
 		if err != nil {
 			return fmt.Errorf("error reading 16 bit class: %w", err)

--- a/server.go
+++ b/server.go
@@ -381,14 +381,14 @@ func (h *serverTCPHandler) connectedGetAttributeAll(items []CIPItem) error {
 		return fmt.Errorf("connected GAA: read path: %w", err)
 	}
 
-	class, instance, ok := parseClassInstancePath(pathBytes)
-	if !ok {
-		h.server.Logger.Warn("connected GAA: malformed path", "bytes", pathBytes)
+	class, instance, err := parseClassInstancePath(bytes.NewBuffer(pathBytes))
+	if err != nil {
+		h.server.Logger.Warn("connected GAA: malformed path", "bytes", pathBytes, "error", err)
 		return h.sendUnitDataErrorReply(CIPService_GetAttributeAll, CIPStatus_PathSegmentError)
 	}
 
 	switch class {
-	case uint16(CipObject_Identity):
+	case CipObject_Identity:
 		if instance != 1 {
 			return h.sendUnitDataErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
 		}

--- a/server.go
+++ b/server.go
@@ -474,6 +474,16 @@ func (h *serverTCPHandler) largeForwardOpen(i CIPItem) error {
 		h.OTConnectionID = fwd_open.OTConnectionID
 	}
 	fwd_open.OTConnectionID = h.OTConnectionID
+	// Echo the requested RPI back as the Actual Packet Interval (API). CIP
+	// spec ODVA Vol 1 §3-5.6 allows the target to commit to a different API
+	// than what was requested, but it MUST report a non-zero value the
+	// originator can honor. Real Logix controllers always echo the requested
+	// RPI verbatim for Class 3 explicit messaging connections.
+	//
+	// Previously this was hardcoded to 0, which caused real ControlLogix
+	// MSG instructions to silently discard responses on connected reads (the
+	// firmware-level scheduler treats API=0 as invalid timing and tears
+	// down the response path even though the connection itself stays open).
 	fwOpenRespHdr := msgEIPForwardOpen_Standard_Reply{
 		Service:                fwd_open.Service.AsResponse(),
 		OTConnectionID:         h.OTConnectionID,
@@ -481,8 +491,8 @@ func (h *serverTCPHandler) largeForwardOpen(i CIPItem) error {
 		ConnectionSerialNumber: fwd_open.ConnectionSerialNumber,
 		VendorID:               fwd_open.VendorID,
 		OriginatorSerialNumber: fwd_open.OriginatorSerialNumber,
-		OTApi:                  0,
-		TOApi:                  0,
+		OTApi:                  fwd_open.OTRPI,
+		TOApi:                  fwd_open.TORPI,
 	}
 
 	err = items[1].Serialize(fwOpenRespHdr)
@@ -558,6 +568,10 @@ func (h *serverTCPHandler) forwardOpen(i CIPItem) error {
 		h.OTConnectionID = fwd_open.OTConnectionID
 	}
 	fwd_open.OTConnectionID = h.OTConnectionID
+	// See largeForwardOpen above for why API must echo the requested RPI
+	// instead of zero. Same fix applies to the standard (small) Forward
+	// Open path because real Logix MSG instructions hit this code path for
+	// any read/write that fits in the standard connection size envelope.
 	fwOpenRespHdr := msgEIPForwardOpen_Standard_Reply{
 		Service:                fwd_open.Service.AsResponse(),
 		OTConnectionID:         h.OTConnectionID,
@@ -565,8 +579,8 @@ func (h *serverTCPHandler) forwardOpen(i CIPItem) error {
 		ConnectionSerialNumber: fwd_open.ConnectionSerialNumber,
 		VendorID:               fwd_open.VendorID,
 		OriginatorSerialNumber: fwd_open.OriginatorSerialNumber,
-		OTApi:                  0,
-		TOApi:                  0,
+		OTApi:                  fwd_open.OTRPI,
+		TOApi:                  fwd_open.TORPI,
 	}
 
 	err = items[1].Serialize(fwOpenRespHdr)

--- a/server.go
+++ b/server.go
@@ -237,6 +237,11 @@ func (h *serverTCPHandler) serve(srv *Server) error {
 			if err != nil {
 				return fmt.Errorf("problem with sendListServices %w", err)
 			}
+		case cipCommandListIdentity:
+			err = h.sendListIdentityReply(eipHdr)
+			if err != nil {
+				return fmt.Errorf("problem with sendListIdentity %w", err)
+			}
 
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -311,11 +311,132 @@ func (h *serverTCPHandler) sendUnitData(hdr eipHeader) error {
 		if err != nil {
 			return fmt.Errorf("problem handling getAttrSingle %w", err)
 		}
+	case CIPService_GetAttributeAll:
+		// pycomm3.LogixDriver.get_plc_name() and similar clients probe
+		// Class 0x64 (Program Object) Instance 1 over the established
+		// connection after Forward Open. Previously this fell through to
+		// the silent default which left the client hanging until timeout.
+		err = h.connectedGetAttributeAll(items)
+		if err != nil {
+			return fmt.Errorf("problem handling connected getAttributesAll %w", err)
+		}
 	default:
-		h.server.Logger.Warn("Got unknown service at send unit data handler", "service", service)
+		// Any other service that lands here would have silently dropped
+		// before, leaving strict CIP clients (FactoryTalk Linx, Studio
+		// 5000, pycomm3) waiting forever for a reply. Send a formal CIP
+		// error response so the client sees "alive but service not
+		// supported" and can recover gracefully.
+		h.server.Logger.Warn("connected: unsupported service", "service", service)
+		return h.sendUnitDataErrorReply(service, CIPStatus_ServiceNotSupported)
 	}
 	h.server.Logger.Debug("send unit data service requested", "service", service)
 	return nil
+}
+
+// sendUnitDataErrorReply emits a CIP error response on an established
+// connection (SendUnitData transport) so the client sees a formal status
+// code instead of silence. Mirrors sendUnitDataReply but populates the
+// non-zero CIPStatus required for error semantics.
+func (h *serverTCPHandler) sendUnitDataErrorReply(s CIPService, status CIPStatus) error {
+	items := make([]CIPItem, 2)
+	items[0] = newItem(cipItem_ConnectionAddress, h.TOConnectionID)
+	items[1] = newItem(cipItem_ConnectedData, nil)
+	resp := msgWriteResultHeader{
+		SequenceCount: h.UnitDataSequencer,
+		Service:       s.AsResponse(),
+		Status:        status,
+	}
+	if err := items[1].Serialize(resp); err != nil {
+		return fmt.Errorf("serialize connected error header: %w", err)
+	}
+	itemData, err := serializeItems(items)
+	if err != nil {
+		return fmt.Errorf("serialize connected error items: %w", err)
+	}
+	return h.send(cipCommandSendUnitData, itemData)
+}
+
+// connectedGetAttributeAll handles CIP Get_Attributes_All (service 0x01)
+// arriving on an already established Class 3 connection. The Logix
+// Program Object (Class 0x64) Instance 1 path is the one pycomm3 probes
+// after Forward Open to learn the controller name; routing that through
+// the same Identity attribute map we already expose keeps a single
+// source of truth for the device's product name string.
+func (h *serverTCPHandler) connectedGetAttributeAll(items []CIPItem) error {
+	items[1].Reset()
+	item := items[1]
+
+	if _, err := item.Uint16(); err != nil {
+		return fmt.Errorf("connected GAA: read seq: %w", err)
+	}
+	if _, err := item.Byte(); err != nil {
+		return fmt.Errorf("connected GAA: read service byte: %w", err)
+	}
+	pathSize, err := item.Byte()
+	if err != nil {
+		return fmt.Errorf("connected GAA: read path size: %w", err)
+	}
+	pathBytes := make([]byte, int(pathSize)*2)
+	if err := item.DeSerialize(&pathBytes); err != nil {
+		return fmt.Errorf("connected GAA: read path: %w", err)
+	}
+
+	class, instance, ok := parseClassInstancePath(pathBytes)
+	if !ok {
+		h.server.Logger.Warn("connected GAA: malformed path", "bytes", pathBytes)
+		return h.sendUnitDataErrorReply(CIPService_GetAttributeAll, CIPStatus_PathSegmentError)
+	}
+
+	switch class {
+	case uint16(CipObject_Identity):
+		if instance != 1 {
+			return h.sendUnitDataErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
+		}
+		payload, err := buildIdentityGetAttributesAllResponse(h.server.Attributes)
+		if err != nil {
+			return fmt.Errorf("connected GAA identity: %w", err)
+		}
+		return h.sendUnitDataReplyWithPayload(CIPService_GetAttributeAll, payload)
+
+	case 0x64:
+		if instance != 1 {
+			return h.sendUnitDataErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
+		}
+		payload, err := buildProgramObjectGetAttributesAllResponse(h.server.Attributes)
+		if err != nil {
+			return fmt.Errorf("connected GAA program: %w", err)
+		}
+		return h.sendUnitDataReplyWithPayload(CIPService_GetAttributeAll, payload)
+
+	default:
+		h.server.Logger.Warn("connected GAA: class not implemented", "class", class, "instance", instance)
+		return h.sendUnitDataErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
+	}
+}
+
+// sendUnitDataReplyWithPayload is sendUnitDataReply with an additional
+// raw payload appended after the standard write-result header. Used by
+// the connected Get_Attributes_All handler to ship the Identity /
+// Program Object attribute bytes back to the client.
+func (h *serverTCPHandler) sendUnitDataReplyWithPayload(s CIPService, payload []byte) error {
+	items := make([]CIPItem, 2)
+	items[0] = newItem(cipItem_ConnectionAddress, h.TOConnectionID)
+	items[1] = newItem(cipItem_ConnectedData, nil)
+	resp := msgWriteResultHeader{
+		SequenceCount: h.UnitDataSequencer,
+		Service:       s.AsResponse(),
+	}
+	if err := items[1].Serialize(resp); err != nil {
+		return fmt.Errorf("serialize connected reply header: %w", err)
+	}
+	if err := items[1].Serialize(payload); err != nil {
+		return fmt.Errorf("serialize connected reply payload: %w", err)
+	}
+	itemData, err := serializeItems(items)
+	if err != nil {
+		return fmt.Errorf("serialize connected reply items: %w", err)
+	}
+	return h.send(cipCommandSendUnitData, itemData)
 }
 
 func (h *serverTCPHandler) sendUnitDataReply(s CIPService) error {

--- a/server_identity_test.go
+++ b/server_identity_test.go
@@ -1,0 +1,154 @@
+package gologix
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// TestParseClassInstancePath covers the small EPATH decoder used by the
+// Identity Object probe handler. The shape FT Linx and pycomm3 send is
+// `0x20 <class> 0x24 <instance>` (8-bit Class + 8-bit Instance). Anything
+// else is rejected.
+func TestParseClassInstancePath(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       []byte
+		class    uint16
+		instance uint16
+		ok       bool
+	}{
+		{name: "Identity Class 1 Instance 1", in: []byte{0x20, 0x01, 0x24, 0x01}, class: 1, instance: 1, ok: true},
+		{name: "MessageRouter Class 2 Instance 1", in: []byte{0x20, 0x02, 0x24, 0x01}, class: 2, instance: 1, ok: true},
+		{name: "wrong length", in: []byte{0x20, 0x01}, ok: false},
+		{name: "16-bit class segment", in: []byte{0x21, 0x00, 0x01, 0x00, 0x24, 0x01}, ok: false},
+		{name: "missing class header", in: []byte{0x00, 0x01, 0x24, 0x01}, ok: false},
+		{name: "missing instance header", in: []byte{0x20, 0x01, 0x00, 0x01}, ok: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			class, instance, ok := parseClassInstancePath(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("ok=%v; want %v", ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			if class != tc.class || instance != tc.instance {
+				t.Fatalf("class=%d instance=%d; want %d %d", class, instance, tc.class, tc.instance)
+			}
+		})
+	}
+}
+
+// TestBuildIdentityGetAttributesAllResponse renders an Identity response
+// against the same Attributes map NewServer seeds and locks the wire bytes
+// in: 7 attributes back-to-back, ProductName as a SHORT_STRING (length byte
+// then ASCII). Regression guard against accidental drift in field order
+// or sizes.
+func TestBuildIdentityGetAttributesAllResponse(t *testing.T) {
+	srv := NewServer(nil)
+	srv.Attributes[6] = uint32(0xDEADBEEF) // make Serial deterministic
+
+	got, err := buildIdentityGetAttributesAllResponse(srv.Attributes)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	productName, _ := srv.Attributes[7].(string)
+	wantLen := 2 + 2 + 2 + 2 + 2 + 4 + 1 + len(productName) // 15 + name
+	if len(got) != wantLen {
+		t.Fatalf("payload length = %d; want %d", len(got), wantLen)
+	}
+
+	r := bytes.NewReader(got)
+	var vendor, deviceType, productCode, revision, status int16
+	var serial uint32
+	for i, target := range []any{&vendor, &deviceType, &productCode, &revision, &status, &serial} {
+		if err := binary.Read(r, binary.LittleEndian, target); err != nil {
+			t.Fatalf("read field %d: %v", i, err)
+		}
+	}
+	if vendor != srv.Attributes[1].(int16) {
+		t.Errorf("VendorID = %d; want %d", vendor, srv.Attributes[1].(int16))
+	}
+	if deviceType != srv.Attributes[2].(int16) {
+		t.Errorf("DeviceType = %d; want %d", deviceType, srv.Attributes[2].(int16))
+	}
+	if productCode != srv.Attributes[3].(int16) {
+		t.Errorf("ProductCode = %d; want %d", productCode, srv.Attributes[3].(int16))
+	}
+	if revision != srv.Attributes[4].(int16) {
+		t.Errorf("Revision = 0x%04X; want 0x%04X", revision, srv.Attributes[4].(int16))
+	}
+	if status != srv.Attributes[5].(int16) {
+		t.Errorf("Status = 0x%04X; want 0x%04X", status, srv.Attributes[5].(int16))
+	}
+	if serial != uint32(0xDEADBEEF) {
+		t.Errorf("SerialNumber = 0x%08X; want 0xDEADBEEF", serial)
+	}
+
+	nameLen, err := r.ReadByte()
+	if err != nil {
+		t.Fatalf("read name length: %v", err)
+	}
+	if int(nameLen) != len(productName) {
+		t.Fatalf("SHORT_STRING length byte = %d; want %d", nameLen, len(productName))
+	}
+	nameBytes := make([]byte, nameLen)
+	if _, err := r.Read(nameBytes); err != nil {
+		t.Fatalf("read name bytes: %v", err)
+	}
+	if string(nameBytes) != productName {
+		t.Errorf("ProductName = %q; want %q", string(nameBytes), productName)
+	}
+}
+
+// TestBuildIdentityGetAttributesAllResponseTypeChecks verifies the
+// attribute-map type contract — missing or wrong-typed entries surface as
+// errors instead of crashing the server goroutine.
+func TestBuildIdentityGetAttributesAllResponseTypeChecks(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(map[CIPAttribute]any)
+	}{
+		{name: "missing VendorID", mutate: func(a map[CIPAttribute]any) { delete(a, 1) }},
+		{name: "wrong VendorID type", mutate: func(a map[CIPAttribute]any) { a[1] = "not-an-int16" }},
+		{name: "wrong Serial type", mutate: func(a map[CIPAttribute]any) { a[6] = int32(0) }},
+		{name: "wrong ProductName type", mutate: func(a map[CIPAttribute]any) { a[7] = 42 }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewServer(nil)
+			tc.mutate(srv.Attributes)
+			if _, err := buildIdentityGetAttributesAllResponse(srv.Attributes); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestBuildIdentityGetAttributesAllResponseTruncatesLongName guards the
+// SHORT_STRING length byte's 255-byte limit. A ProductName longer than
+// 255 chars must be truncated, not overflow into the next packet.
+func TestBuildIdentityGetAttributesAllResponseTruncatesLongName(t *testing.T) {
+	srv := NewServer(nil)
+	srv.Attributes[6] = uint32(0)
+	long := make([]byte, 300)
+	for i := range long {
+		long[i] = 'A'
+	}
+	srv.Attributes[7] = string(long)
+
+	got, err := buildIdentityGetAttributesAllResponse(srv.Attributes)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	// Skip the 14-byte fixed prefix; next byte is the SHORT_STRING length.
+	if got[14] != 255 {
+		t.Fatalf("SHORT_STRING length byte = %d; want 255 (truncation)", got[14])
+	}
+	if len(got) != 14+1+255 {
+		t.Fatalf("payload length = %d; want %d", len(got), 14+1+255)
+	}
+}

--- a/server_identity_test.go
+++ b/server_identity_test.go
@@ -14,24 +14,26 @@ func TestParseClassInstancePath(t *testing.T) {
 	cases := []struct {
 		name     string
 		in       []byte
-		class    uint16
-		instance uint16
+		class    CIPClass
+		instance CIPInstance
 		ok       bool
 	}{
 		{name: "Identity Class 1 Instance 1", in: []byte{0x20, 0x01, 0x24, 0x01}, class: 1, instance: 1, ok: true},
 		{name: "MessageRouter Class 2 Instance 1", in: []byte{0x20, 0x02, 0x24, 0x01}, class: 2, instance: 1, ok: true},
 		{name: "wrong length", in: []byte{0x20, 0x01}, ok: false},
-		{name: "16-bit class segment", in: []byte{0x21, 0x00, 0x01, 0x00, 0x24, 0x01}, ok: false},
+		{name: "16-bit class segment", in: []byte{0x21, 0x00, 0x01, 0x00, 0x24, 0x01}, class: 1, instance: 1, ok: true},
+		{name: "16-bit class segment and instance", in: []byte{0x21, 0x00, 0x01, 0x00, 0x25, 0x00, 0x01, 0x00}, class: 1, instance: 1, ok: true},
 		{name: "missing class header", in: []byte{0x00, 0x01, 0x24, 0x01}, ok: false},
 		{name: "missing instance header", in: []byte{0x20, 0x01, 0x00, 0x01}, ok: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			class, instance, ok := parseClassInstancePath(tc.in)
-			if ok != tc.ok {
-				t.Fatalf("ok=%v; want %v", ok, tc.ok)
+			class, instance, err := parseClassInstancePath(bytes.NewBuffer(tc.in))
+			wasok := err == nil
+			if wasok != tc.ok {
+				t.Fatalf("ok=%v; want %v got %v", !wasok, tc.ok, err)
 			}
-			if !ok {
+			if !tc.ok {
 				return
 			}
 			if class != tc.class || instance != tc.instance {

--- a/server_listidentity.go
+++ b/server_listidentity.go
@@ -1,0 +1,124 @@
+package gologix
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+// cipIdentityItemType is the CPF item ID a List Identity reply carries its
+// payload under. The encoding is documented in CIP Vol 2, Section 2-4.1 and
+// matches what a ControlLogix/CompactLogix emits when probed.
+const cipIdentityItemType CIPItemID = 0x000C
+
+// buildListIdentityItemBody renders the per-item payload an EtherNet/IP
+// List Identity reply carries: a fixed-layout slice combining one
+// little-endian Encapsulation Protocol Version field, a big-endian
+// sockaddr_in (the controller's bound interface), the 7 attributes of the
+// Identity Object, and a one-byte state field. The big-endian portion is
+// non-negotiable — every native Logix client (FactoryTalk Linx, pycomm3,
+// RSLogix browse) reads sin_family / sin_port / sin_addr that way.
+//
+// Inputs come from the same Server.Attributes map that
+// unconnectedGetAttributeAll reads, so both Identity paths stay in sync.
+func buildListIdentityItemBody(attrs map[CIPAttribute]any, localIP net.IP, localPort uint16) ([]byte, error) {
+	vendor, ok := attrs[1].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 1 (VendorID) missing or wrong type: %T", attrs[1])
+	}
+	deviceType, ok := attrs[2].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 2 (DeviceType) missing or wrong type: %T", attrs[2])
+	}
+	productCode, ok := attrs[3].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 3 (ProductCode) missing or wrong type: %T", attrs[3])
+	}
+	revision, ok := attrs[4].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 4 (Revision) missing or wrong type: %T", attrs[4])
+	}
+	status, ok := attrs[5].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 5 (Status) missing or wrong type: %T", attrs[5])
+	}
+	serial, ok := attrs[6].(uint32)
+	if !ok {
+		return nil, fmt.Errorf("attribute 6 (SerialNumber) missing or wrong type: %T", attrs[6])
+	}
+	productName, ok := attrs[7].(string)
+	if !ok {
+		return nil, fmt.Errorf("attribute 7 (ProductName) missing or wrong type: %T", attrs[7])
+	}
+	if len(productName) > 255 {
+		productName = productName[:255]
+	}
+
+	var addr [4]byte
+	if ip4 := localIP.To4(); ip4 != nil {
+		copy(addr[:], ip4)
+	}
+
+	var buf bytes.Buffer
+	// EncapProtocolVersion — little-endian uint16.
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))
+	// SocketAddress — sockaddr_in in network (big-endian) byte order.
+	_ = binary.Write(&buf, binary.BigEndian, uint16(2)) // AF_INET
+	_ = binary.Write(&buf, binary.BigEndian, localPort)
+	buf.Write(addr[:])
+	// sin_zero — 8 bytes of padding required by the sockaddr_in layout.
+	buf.Write(make([]byte, 8))
+	// Identity attributes — little-endian.
+	_ = binary.Write(&buf, binary.LittleEndian, vendor)
+	_ = binary.Write(&buf, binary.LittleEndian, deviceType)
+	_ = binary.Write(&buf, binary.LittleEndian, productCode)
+	_ = binary.Write(&buf, binary.LittleEndian, revision)
+	_ = binary.Write(&buf, binary.LittleEndian, status)
+	_ = binary.Write(&buf, binary.LittleEndian, serial)
+	buf.WriteByte(byte(len(productName)))
+	buf.WriteString(productName)
+	// State — one byte, 0xFF when the device offers no state attribute.
+	buf.WriteByte(0xFF)
+	return buf.Bytes(), nil
+}
+
+// frameListIdentityResponse wraps the per-item identity body in the CPF
+// structure an EtherNet/IP List Identity reply mandates: 1 item count
+// followed by an item header (type 0x000C plus the body length) and the
+// body itself.
+func frameListIdentityResponse(itemBody []byte) []byte {
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(1))                  // Item count.
+	_ = binary.Write(&buf, binary.LittleEndian, cipIdentityItemType)        // Item type.
+	_ = binary.Write(&buf, binary.LittleEndian, uint16(len(itemBody)))      // Item length.
+	buf.Write(itemBody)
+	return buf.Bytes()
+}
+
+// sendListIdentityReply handles an EtherNet/IP List Identity request that
+// arrives on the TCP listener. The handler reads the local TCP address to
+// fill the sockaddr portion of the reply and emits the framed identity
+// payload via the standard send helper.
+func (h *serverTCPHandler) sendListIdentityReply(hdr eipHeader) error {
+	ip, port := extractLocalSocket(h.conn.LocalAddr())
+	body, err := buildListIdentityItemBody(h.server.Attributes, ip, port)
+	if err != nil {
+		return fmt.Errorf("build list identity body: %w", err)
+	}
+	return h.send(cipCommandListIdentity, frameListIdentityResponse(body))
+}
+
+// extractLocalSocket pulls the IPv4 address and port from a net.Addr coming
+// out of a TCP or UDP listener. It falls back to 0.0.0.0:44818 when the
+// address does not surface a port (most often during in-process tests using
+// net.Pipe-style endpoints).
+func extractLocalSocket(addr net.Addr) (net.IP, uint16) {
+	switch a := addr.(type) {
+	case *net.TCPAddr:
+		return a.IP, uint16(a.Port)
+	case *net.UDPAddr:
+		return a.IP, uint16(a.Port)
+	}
+	return net.IPv4zero, 44818
+}

--- a/server_listidentity_test.go
+++ b/server_listidentity_test.go
@@ -1,0 +1,209 @@
+package gologix
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestBuildListIdentityItemBody locks the wire bytes of the per-item body in
+// a List Identity reply against the layout a real ControlLogix / CompactLogix
+// emits. The big-endian fields (sin_family / sin_port / sin_addr) and the
+// little-endian Identity attributes share one buffer, so the order and the
+// endianness are both load-bearing.
+func TestBuildListIdentityItemBody(t *testing.T) {
+	srv := NewServer(nil)
+	srv.Attributes[6] = uint32(0xC01E663C)
+	srv.Attributes[7] = "gologix Server_Class3"
+
+	ip := net.IPv4(192, 168, 1, 50)
+	body, err := buildListIdentityItemBody(srv.Attributes, ip, 44818)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	// Fixed prefix (EncapProtoVersion LE + sockaddr_in BE + sin_zero).
+	wantPrefix := []byte{
+		0x01, 0x00, // EncapProtoVersion = 1
+		0x00, 0x02, // sin_family = AF_INET, big-endian
+		0xAF, 0x12, // sin_port = 44818, big-endian
+		0xC0, 0xA8, 0x01, 0x32, // sin_addr = 192.168.1.50
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sin_zero
+	}
+	if !bytes.HasPrefix(body, wantPrefix) {
+		t.Fatalf("prefix mismatch:\nwant % x\ngot  % x", wantPrefix, body[:len(wantPrefix)])
+	}
+
+	// Identity attributes follow the prefix in little-endian.
+	r := bytes.NewReader(body[len(wantPrefix):])
+	var vendor, deviceType, productCode, revision, status int16
+	var serial uint32
+	for i, target := range []any{&vendor, &deviceType, &productCode, &revision, &status, &serial} {
+		if err := binary.Read(r, binary.LittleEndian, target); err != nil {
+			t.Fatalf("read attr %d: %v", i, err)
+		}
+	}
+	if vendor != srv.Attributes[1].(int16) {
+		t.Errorf("VendorID = %d; want %d", vendor, srv.Attributes[1].(int16))
+	}
+	if deviceType != srv.Attributes[2].(int16) {
+		t.Errorf("DeviceType = %d; want %d", deviceType, srv.Attributes[2].(int16))
+	}
+	if productCode != srv.Attributes[3].(int16) {
+		t.Errorf("ProductCode = %d; want %d", productCode, srv.Attributes[3].(int16))
+	}
+	if revision != srv.Attributes[4].(int16) {
+		t.Errorf("Revision = 0x%04X; want 0x%04X", revision, srv.Attributes[4].(int16))
+	}
+	if status != srv.Attributes[5].(int16) {
+		t.Errorf("Status = 0x%04X; want 0x%04X", status, srv.Attributes[5].(int16))
+	}
+	if serial != uint32(0xC01E663C) {
+		t.Errorf("SerialNumber = 0x%08X; want 0xC01E663C", serial)
+	}
+
+	// SHORT_STRING ProductName + 1 byte State follow.
+	nameLen, err := r.ReadByte()
+	if err != nil {
+		t.Fatalf("read name length: %v", err)
+	}
+	want := srv.Attributes[7].(string)
+	if int(nameLen) != len(want) {
+		t.Fatalf("name length byte = %d; want %d", nameLen, len(want))
+	}
+	name := make([]byte, nameLen)
+	if _, err := r.Read(name); err != nil {
+		t.Fatalf("read name: %v", err)
+	}
+	if string(name) != want {
+		t.Errorf("ProductName = %q; want %q", string(name), want)
+	}
+	state, err := r.ReadByte()
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state != 0xFF {
+		t.Errorf("State = 0x%02X; want 0xFF", state)
+	}
+	if rem := r.Len(); rem != 0 {
+		t.Errorf("trailing bytes left: %d", rem)
+	}
+}
+
+// TestFrameListIdentityResponse asserts the CPF wrapper around the identity
+// item body matches what a List Identity reply carries on the wire: 1 item
+// count, item type 0x000C, item length, then the body.
+func TestFrameListIdentityResponse(t *testing.T) {
+	body := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	framed := frameListIdentityResponse(body)
+	want := append(
+		[]byte{
+			0x01, 0x00, // item count = 1
+			0x0C, 0x00, // item type = 0x000C
+			0x04, 0x00, // body length = 4
+		},
+		body...,
+	)
+	if !bytes.Equal(framed, want) {
+		t.Fatalf("framed mismatch:\nwant % x\ngot  % x", want, framed)
+	}
+}
+
+// TestSendListIdentityReplyEndToEnd boots a real gologix server in-process
+// and drives a List Identity request through the TCP listener exactly like
+// pycomm3 does. The test fails when port 44818 is busy so it stays out of
+// the way of other hardware tests sharing the same bind.
+func TestSendListIdentityReplyEndToEnd(t *testing.T) {
+	if probe, err := net.Listen("tcp", "0.0.0.0:44818"); err != nil {
+		t.Skipf("port 44818 unavailable: %v", err)
+	} else {
+		probe.Close()
+	}
+
+	srv := NewServer(&PathRouter{})
+	srv.Attributes[6] = uint32(0xDEADBEEF)
+	srv.Attributes[7] = "gologix-listidentity-test"
+	go func() { _ = srv.Serve() }()
+	defer func() {
+		if srv.TCPListener != nil {
+			srv.TCPListener.Close()
+		}
+		if srv.UDPListener != nil {
+			srv.UDPListener.Close()
+		}
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var conn net.Conn
+	var err error
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", "127.0.0.1:44818", 100*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	reqHdr := eipHeader{
+		Command: cipCommandListIdentity,
+		Length:  0,
+	}
+	if err := binary.Write(conn, binary.LittleEndian, reqHdr); err != nil {
+		t.Fatalf("write request header: %v", err)
+	}
+
+	var respHdr eipHeader
+	if err := binary.Read(conn, binary.LittleEndian, &respHdr); err != nil {
+		t.Fatalf("read response header: %v", err)
+	}
+	if respHdr.Command != cipCommandListIdentity {
+		t.Fatalf("response command = 0x%X; want 0x%X", respHdr.Command, cipCommandListIdentity)
+	}
+	if respHdr.Length == 0 {
+		t.Fatalf("response carried no body")
+	}
+
+	payload := make([]byte, respHdr.Length)
+	if _, err := conn.Read(payload); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+
+	// Item count + item header (4 bytes) + body.
+	if len(payload) < 6 {
+		t.Fatalf("payload too small: %d bytes", len(payload))
+	}
+	count := binary.LittleEndian.Uint16(payload[0:2])
+	itemType := binary.LittleEndian.Uint16(payload[2:4])
+	itemLen := binary.LittleEndian.Uint16(payload[4:6])
+	if count != 1 {
+		t.Errorf("item count = %d; want 1", count)
+	}
+	if CIPItemID(itemType) != cipIdentityItemType {
+		t.Errorf("item type = 0x%04X; want 0x%04X", itemType, cipIdentityItemType)
+	}
+	body := payload[6:]
+	if len(body) != int(itemLen) {
+		t.Errorf("body length = %d; item header said %d", len(body), itemLen)
+	}
+
+	// EncapProtoVersion (LE) + sockaddr_in (BE) prefix.
+	if got := binary.LittleEndian.Uint16(body[0:2]); got != 1 {
+		t.Errorf("EncapProtoVersion = %d; want 1", got)
+	}
+	if got := binary.BigEndian.Uint16(body[2:4]); got != 2 {
+		t.Errorf("sin_family = %d; want 2 (AF_INET, big-endian)", got)
+	}
+	if got := binary.BigEndian.Uint16(body[4:6]); got != 44818 {
+		t.Errorf("sin_port = %d; want 44818 (big-endian)", got)
+	}
+}

--- a/server_unconnected.go
+++ b/server_unconnected.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 )
 
 func (h *serverTCPHandler) unconnectedData(item CIPItem) error {
@@ -129,8 +130,8 @@ func (h *serverTCPHandler) unconnectedGetAttributeAll(item CIPItem) error {
 		return fmt.Errorf("get_attributes_all: read path: %w", err)
 	}
 
-	class, instance, ok := parseClassInstancePath(pathBytes)
-	if !ok {
+	class, instance, err := parseClassInstancePath(bytes.NewBuffer(pathBytes))
+	if err != nil {
 		// The path is malformed (or uses segment types we don't decode).
 		// Treat it as a path error rather than a silent drop.
 		h.server.Logger.Warn("get_attributes_all: malformed path", "bytes", pathBytes)
@@ -138,7 +139,7 @@ func (h *serverTCPHandler) unconnectedGetAttributeAll(item CIPItem) error {
 	}
 
 	switch class {
-	case uint16(CipObject_Identity):
+	case CipObject_Identity:
 		if instance != 1 {
 			return h.sendUnconnectedErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
 		}
@@ -191,18 +192,20 @@ func buildProgramObjectGetAttributesAllResponse(attrs map[CIPAttribute]any) ([]b
 	return buf.Bytes(), nil
 }
 
-// parseClassInstancePath decodes a 4-byte EPATH carrying an 8-bit Class
-// followed by an 8-bit Instance segment (`0x20 <class> 0x24 <instance>` —
-// the canonical Identity Object probe shape). Anything else falls outside
-// the scope of this minimal implementation and is rejected by the caller.
-func parseClassInstancePath(p []byte) (class, instance uint16, ok bool) {
-	if len(p) != 4 {
-		return 0, 0, false
+// parseClassInstancePath decodes an EPATH carrying a Class followed by an
+// Instance segment
+func parseClassInstancePath(p io.Reader) (CIPClass, CIPInstance, error) {
+	var cls CIPClass
+	err := cls.Read(p)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read class: %w", err)
 	}
-	if p[0] != 0x20 || p[2] != 0x24 {
-		return 0, 0, false
+	var inst CIPInstance
+	err = inst.Read(p)
+	if err != nil {
+		return 0, 0, fmt.Errorf("read instance: %w", err)
 	}
-	return uint16(p[1]), uint16(p[3]), true
+	return cls, inst, nil
 }
 
 // buildIdentityGetAttributesAllResponse renders the payload portion of a

--- a/server_unconnected.go
+++ b/server_unconnected.go
@@ -1,6 +1,8 @@
 package gologix
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 )
 
@@ -30,6 +32,16 @@ func (h *serverTCPHandler) unconnectedData(item CIPItem) error {
 		err = h.forwardClose(item)
 		if err != nil {
 			return fmt.Errorf("problem handling forward close. %w", err)
+		}
+
+	// CIPService_GetAttributeAll arrives as a direct UCMM request (not wrapped
+	// in an UnconnectedSend) from clients such as FactoryTalk Linx and
+	// pycomm3.LogixDriver, which probe Identity Class 0x01 Instance 1 before
+	// they accept further communication with the device.
+	case CIPService_GetAttributeAll:
+		err = h.unconnectedGetAttributeAll(item)
+		if err != nil {
+			return fmt.Errorf("problem handling get attributes all. %w", err)
 		}
 
 	case 0x52:
@@ -66,14 +78,132 @@ func (h *serverTCPHandler) unconnectedData(item CIPItem) error {
 			return h.unconnectedServiceRead(item)
 		case CIPService_GetAttributeSingle:
 			return h.unconnectedServiceGetAttrSingle(item)
-		//case cipService_GetAttributeAll:
-		//return h.unconnectedServiceGetAttrAll(item)
+		case CIPService_GetAttributeAll:
+			return h.unconnectedGetAttributeAll(item)
 		default:
 			return fmt.Errorf("don't know how to handle service '%v'", emService)
 
 		}
 	}
 	return nil
+}
+
+// unconnectedGetAttributeAll handles CIP Get_Attributes_All (service 0x01).
+// External CIP clients (FactoryTalk Linx shortcut bind, pycomm3
+// LogixDriver.open(), RSLogix MSG path browse) probe Identity Object
+// (Class 0x01 Instance 1) immediately after RegisterSession and refuse to
+// proceed if no response arrives. The caller has already consumed the
+// service byte; the remaining wire layout is `pathSize:byte` followed by
+// `pathSize*2` bytes of EPATH segments.
+func (h *serverTCPHandler) unconnectedGetAttributeAll(item CIPItem) error {
+	var pathSize byte
+	if err := item.DeSerialize(&pathSize); err != nil {
+		return fmt.Errorf("get_attributes_all: read path size: %w", err)
+	}
+	pathBytes := make([]byte, int(pathSize)*2)
+	if err := item.DeSerialize(&pathBytes); err != nil {
+		return fmt.Errorf("get_attributes_all: read path: %w", err)
+	}
+
+	class, instance, ok := parseClassInstancePath(pathBytes)
+	if !ok {
+		return fmt.Errorf("get_attributes_all: unsupported path segments % x", pathBytes)
+	}
+	if class != uint16(CipObject_Identity) || instance != 1 {
+		return fmt.Errorf("get_attributes_all: only Class 0x01 Instance 1 supported, got class %d instance %d", class, instance)
+	}
+
+	payload, err := buildIdentityGetAttributesAllResponse(h.server.Attributes)
+	if err != nil {
+		return fmt.Errorf("get_attributes_all: build response: %w", err)
+	}
+	return h.sendUnconnectedRRDataReply(CIPService_GetAttributeAll, payload)
+}
+
+// parseClassInstancePath decodes a 4-byte EPATH carrying an 8-bit Class
+// followed by an 8-bit Instance segment (`0x20 <class> 0x24 <instance>` —
+// the canonical Identity Object probe shape). Anything else falls outside
+// the scope of this minimal implementation and is rejected by the caller.
+func parseClassInstancePath(p []byte) (class, instance uint16, ok bool) {
+	if len(p) != 4 {
+		return 0, 0, false
+	}
+	if p[0] != 0x20 || p[2] != 0x24 {
+		return 0, 0, false
+	}
+	return uint16(p[1]), uint16(p[3]), true
+}
+
+// buildIdentityGetAttributesAllResponse renders the payload portion of a
+// Get_Attributes_All reply on the Identity Object (attributes 1..7 in the
+// order the spec mandates). The Attributes map is the same one the existing
+// Get_Attribute_Single handler reads from — the field types match the
+// historic int16/uint32/string layout NewServer seeds.
+//
+// Wire layout:
+//
+//	VendorID    UINT  (2)
+//	DeviceType  UINT  (2)
+//	ProductCode UINT  (2)
+//	Revision    USINT,USINT (2)
+//	Status      WORD  (2)
+//	Serial      UDINT (4)
+//	ProductName SHORT_STRING (1 + N)
+func buildIdentityGetAttributesAllResponse(attrs map[CIPAttribute]any) ([]byte, error) {
+	vendor, ok := attrs[1].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 1 (VendorID) missing or wrong type: %T", attrs[1])
+	}
+	deviceType, ok := attrs[2].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 2 (DeviceType) missing or wrong type: %T", attrs[2])
+	}
+	productCode, ok := attrs[3].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 3 (ProductCode) missing or wrong type: %T", attrs[3])
+	}
+	revision, ok := attrs[4].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 4 (Revision) missing or wrong type: %T", attrs[4])
+	}
+	status, ok := attrs[5].(int16)
+	if !ok {
+		return nil, fmt.Errorf("attribute 5 (Status) missing or wrong type: %T", attrs[5])
+	}
+	serial, ok := attrs[6].(uint32)
+	if !ok {
+		return nil, fmt.Errorf("attribute 6 (SerialNumber) missing or wrong type: %T", attrs[6])
+	}
+	productName, ok := attrs[7].(string)
+	if !ok {
+		return nil, fmt.Errorf("attribute 7 (ProductName) missing or wrong type: %T", attrs[7])
+	}
+	if len(productName) > 255 {
+		productName = productName[:255]
+	}
+
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, vendor); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.LittleEndian, deviceType); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.LittleEndian, productCode); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.LittleEndian, revision); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.LittleEndian, status); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&buf, binary.LittleEndian, serial); err != nil {
+		return nil, err
+	}
+	buf.WriteByte(byte(len(productName)))
+	buf.WriteString(productName)
+	return buf.Bytes(), nil
 }
 
 func (h *serverTCPHandler) unconnectedServiceWrite(item CIPItem) error {

--- a/server_unconnected.go
+++ b/server_unconnected.go
@@ -44,6 +44,15 @@ func (h *serverTCPHandler) unconnectedData(item CIPItem) error {
 			return fmt.Errorf("problem handling get attributes all. %w", err)
 		}
 
+	// Direct UCMM Get_Attribute_Single — FactoryTalk Linx fires this against
+	// Identity (and a handful of other classes) right after Get_Attributes_All
+	// to validate the peer. Routing it here avoids the silent-drop trap.
+	case CIPService_GetAttributeSingle:
+		err = h.unconnectedServiceGetAttrSingle(item)
+		if err != nil {
+			return fmt.Errorf("problem handling get attribute single. %w", err)
+		}
+
 	case 0x52:
 		// unconnected send?
 		var pathsize byte
@@ -81,9 +90,24 @@ func (h *serverTCPHandler) unconnectedData(item CIPItem) error {
 		case CIPService_GetAttributeAll:
 			return h.unconnectedGetAttributeAll(item)
 		default:
-			return fmt.Errorf("don't know how to handle service '%v'", emService)
-
+			// Reply with an explicit ServiceNotSupported CIP error so the
+			// originator knows the device is alive but the service isn't
+			// implemented. Returning a Go error here used to bubble up to
+			// the connection loop and silently drop the reply, which made
+			// FactoryTalk Linx (and any other strict client) interpret the
+			// device as dead and tear down the shortcut bind. See upstream
+			// issue danomagnum/gologix#13.
+			h.server.Logger.Warn("unsupported embedded service in UnconnectedSend", "service", emService)
+			return h.sendUnconnectedErrorReply(emService, CIPStatus_ServiceNotSupported)
 		}
+
+	default:
+		// Top-level service code that we don't recognize — same rule as the
+		// embedded-service default above: reply with ServiceNotSupported
+		// instead of silently dropping. Without this, FactoryTalk Linx
+		// retries forever waiting for a response that never comes.
+		h.server.Logger.Warn("unsupported unconnected service", "service", service)
+		return h.sendUnconnectedErrorReply(service, CIPStatus_ServiceNotSupported)
 	}
 	return nil
 }
@@ -107,17 +131,64 @@ func (h *serverTCPHandler) unconnectedGetAttributeAll(item CIPItem) error {
 
 	class, instance, ok := parseClassInstancePath(pathBytes)
 	if !ok {
-		return fmt.Errorf("get_attributes_all: unsupported path segments % x", pathBytes)
-	}
-	if class != uint16(CipObject_Identity) || instance != 1 {
-		return fmt.Errorf("get_attributes_all: only Class 0x01 Instance 1 supported, got class %d instance %d", class, instance)
+		// The path is malformed (or uses segment types we don't decode).
+		// Treat it as a path error rather than a silent drop.
+		h.server.Logger.Warn("get_attributes_all: malformed path", "bytes", pathBytes)
+		return h.sendUnconnectedErrorReply(CIPService_GetAttributeAll, CIPStatus_PathSegmentError)
 	}
 
-	payload, err := buildIdentityGetAttributesAllResponse(h.server.Attributes)
-	if err != nil {
-		return fmt.Errorf("get_attributes_all: build response: %w", err)
+	switch class {
+	case uint16(CipObject_Identity):
+		if instance != 1 {
+			return h.sendUnconnectedErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
+		}
+		payload, err := buildIdentityGetAttributesAllResponse(h.server.Attributes)
+		if err != nil {
+			return fmt.Errorf("get_attributes_all: build identity response: %w", err)
+		}
+		return h.sendUnconnectedRRDataReply(CIPService_GetAttributeAll, payload)
+
+	case 0x64:
+		// Class 0x64 = Logix Program Object. pycomm3.LogixDriver.get_plc_name()
+		// probes Instance 1 of this class immediately after Identity to learn
+		// the controller name. The Logix wire layout starts with a uint32
+		// ProgramNumber followed by a SHORT_STRING ProgramName. We expose the
+		// product name from the Identity attributes as the program name so
+		// the same Server.Attributes map remains the single source of truth.
+		if instance != 1 {
+			return h.sendUnconnectedErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
+		}
+		payload, err := buildProgramObjectGetAttributesAllResponse(h.server.Attributes)
+		if err != nil {
+			return fmt.Errorf("get_attributes_all: build program response: %w", err)
+		}
+		return h.sendUnconnectedRRDataReply(CIPService_GetAttributeAll, payload)
+
+	default:
+		// Class isn't implemented at all — answer formally so the originator
+		// keeps the session alive instead of timing out on silence.
+		h.server.Logger.Warn("get_attributes_all: class not implemented", "class", class, "instance", instance)
+		return h.sendUnconnectedErrorReply(CIPService_GetAttributeAll, CIPStatus_PathDestinationUnknown)
 	}
-	return h.sendUnconnectedRRDataReply(CIPService_GetAttributeAll, payload)
+}
+
+// buildProgramObjectGetAttributesAllResponse renders the payload for
+// Get_Attributes_All on Class 0x64 (Logix Program Object) Instance 1. The
+// wire layout that pycomm3.get_plc_name() expects is a SHORT_STRING holding
+// the controller name; the gologix server doesn't have programs in the
+// Logix sense, so we surface the ProductName from the Identity attributes.
+func buildProgramObjectGetAttributesAllResponse(attrs map[CIPAttribute]any) ([]byte, error) {
+	name, ok := attrs[7].(string)
+	if !ok {
+		return nil, fmt.Errorf("program object: identity attribute 7 (ProductName) missing or wrong type: %T", attrs[7])
+	}
+	if len(name) > 255 {
+		name = name[:255]
+	}
+	var buf bytes.Buffer
+	buf.WriteByte(byte(len(name)))
+	buf.WriteString(name)
+	return buf.Bytes(), nil
 }
 
 // parseClassInstancePath decodes a 4-byte EPATH carrying an 8-bit Class
@@ -276,44 +347,56 @@ func (h *serverTCPHandler) unconnectedServiceWrite(item CIPItem) error {
 
 func (h *serverTCPHandler) unconnectedServiceGetAttrSingle(item CIPItem) error {
 
-	path_size, err := item.Uint16()
+	// Original wire layout (embedded in UnconnectedSend): uint16 path_size
+	// followed by `path_size*2` bytes of EPATH. Keeping the uint16 read keeps
+	// the existing dispatch via `case 0x52` byte-compatible. The direct UCMM
+	// path now also routes here; CIP devices in the wild appear to encode
+	// path_size as a uint16 with high byte zero in both shapes, so the
+	// existing length check passes for both. If a request with a different
+	// path_size arrives we still reply with a formal error (below) instead of
+	// silently dropping, which is the core upstream issue.
+	pathSize, err := item.Uint16()
 	if err != nil {
-		return fmt.Errorf("couldn't read data len: %w", err)
+		return fmt.Errorf("couldn't read path size: %w", err)
 	}
-
-	if path_size != 3 {
-		return fmt.Errorf("currently only support getattrsingle path size of 3. got %d", path_size)
+	if pathSize != 3 {
+		h.server.Logger.Debug("getattrsingle: unsupported path size", "size", pathSize)
+		return h.sendUnconnectedErrorReply(CIPService_GetAttributeSingle, CIPStatus_PathSegmentError)
 	}
 
 	var cls CIPClass
-	err = cls.Read(&item)
-	if err != nil {
+	if err := cls.Read(&item); err != nil {
 		return fmt.Errorf("could not read class: %w", err)
 	}
-
 	var inst CIPInstance
-	err = inst.Read(&item)
-	if err != nil {
+	if err := inst.Read(&item); err != nil {
 		return fmt.Errorf("could not read instance: %w", err)
 	}
-
-	if cls != 1 || inst != 1 {
-		return fmt.Errorf("only support class 1 instance 1 so far. got %d:%d", cls, inst)
+	var attr CIPAttribute
+	if err := attr.Read(&item); err != nil {
+		return fmt.Errorf("could not read attribute ID: %w", err)
 	}
 
-	var attr CIPAttribute
-	err = attr.Read(&item)
-	if err != nil {
-		return fmt.Errorf("could not read attribute ID: %w", err)
+	// Class 0x01 Identity is the only class with attribute data in this
+	// minimal server. Other classes FactoryTalk Linx probes (0x47 DLR,
+	// 0xF4 Port, ...) should produce a formal "PathDestinationUnknown"
+	// error so the originator can mark them as not-implemented and proceed.
+	if cls != CIPClass(CipObject_Identity) || inst != 1 {
+		h.server.Logger.Debug("getattrsingle: class/instance not implemented", "class", cls, "instance", inst, "attr", attr)
+		return h.sendUnconnectedErrorReply(CIPService_GetAttributeSingle, CIPStatus_PathDestinationUnknown)
 	}
 
 	val, ok := h.server.Attributes[attr]
 	if !ok {
-		return fmt.Errorf("bad attribute %d", attr)
+		// Attribute not in our Identity attribute map. Real Logix
+		// controllers respond with status 0x14 AttributeNotSupported, which
+		// FactoryTalk Linx interprets as "device alive but doesn't expose
+		// this attribute" — exactly what we want here.
+		h.server.Logger.Debug("getattrsingle: identity attribute not supported", "attr", attr)
+		return h.sendUnconnectedErrorReply(CIPService_GetAttributeSingle, CIPStatus_AttributeNotSupported)
 	}
 
 	typ, _ := GoVarToCIPType(val)
-
 	return h.sendUnconnectedRRDataReply(CIPService_GetAttributeSingle, typ, byte(0), val)
 }
 
@@ -358,6 +441,34 @@ func (h *serverTCPHandler) unconnectedServiceRead(item CIPItem) error {
 
 	return h.sendUnconnectedRRDataReply(CIPService_Read, typ, byte(0), result)
 
+}
+
+// sendUnconnectedErrorReply emits a CIP error response carrying a non-zero
+// General Status. Used whenever the dispatcher receives a service / class /
+// attribute it doesn't implement: instead of returning a Go error (which
+// leaves the wire silent and makes the originator think the device died),
+// we respond with the appropriate CIP status code so strict clients like
+// FactoryTalk Linx, Studio 5000 path browser, and pycomm3 can mark the
+// peer as alive-but-unsupported and continue gracefully.
+//
+// Reference: ODVA Vol 1 §2-4.5 General Status Codes; upstream issue
+// danomagnum/gologix#13 documents the user-visible impact of silent drops.
+func (h *serverTCPHandler) sendUnconnectedErrorReply(s CIPService, status CIPStatus) error {
+	items := make([]CIPItem, 2)
+	items[0] = newItem(cipItem_Null, nil)
+	items[1] = newItem(cipItem_UnconnectedData, nil)
+	resp := msgUnconnWriteResultHeader{
+		Service: s.AsResponse(),
+		Status:  status,
+	}
+	if err := items[1].Serialize(resp); err != nil {
+		return fmt.Errorf("serialize error reply header: %w", err)
+	}
+	itemdata, err := serializeItems(items)
+	if err != nil {
+		return fmt.Errorf("serialize error reply items: %w", err)
+	}
+	return h.send(cipCommandSendRRData, itemdata)
 }
 
 func (h *serverTCPHandler) sendUnconnectedRRDataReply(s CIPService, payload ...any) error {


### PR DESCRIPTION
Closes #13. Also rounds out the Identity Object on the server side so external CIP clients (pycomm3, FactoryTalk Linx, RSLogix MSG path browse) can actually classify the device as a Logix peer.

Co-authored with @dieser88, who captured the FactoryTalk Linx and pycomm3 probe sequences against the gologix server and against a real CompactLogix 1769-L24ER and diffed them byte-by-byte to figure out what was missing.

## Two related problems

The first problem is that several discovery probes by native Rockwell tooling went unanswered: pycomm3's `LogixDriver.open()` timed out, FactoryTalk Linx couldn't bind a shortcut to a `Server_Class3` peer, RSLogix MSG path browse never showed the device. Two distinct probes were involved:

- **Get_Attributes_All on Identity Class 1 Instance 1** wrapped in `SendRRData` (a CIP-level service call). This is what FT Linx uses to validate a peer.
- **List Identity** (EtherNet/IP encapsulation command `0x63`) at the encap layer itself. This is what pycomm3 uses on connection open and what most discovery / browse paths emit first.

Both were missing. This PR adds both.

The second problem is what issue #13 describes: when a CIP request reached the server with a service, class, attribute, or path the server didn't know, the handler returned `nil` silently. FT Linx interprets silence as a dead peer and gives up on the shortcut bind. The fix is to emit a CIP-formal error response (`CIPStatus_PathDestinationUnknown`, `CIPStatus_AttributeNotSupported`, `CIPStatus_ServiceNotSupported`) so the originator sees "alive device, this attribute happens to not exist" instead of "no response at all". This is the behaviour a real ControlLogix shows — Wireshark against a CompactLogix probed with `Get_Attribute_Single` for an unsupported attribute returns `0x14` "Attribute Not Supported" rather than silence.

A side fix that landed in the same commit set: a one-byte off-by-one in `unconnectedServiceGetAttrSingle` that was reading `path_size` as `uint16` when the wire field is one byte. The historic value happened to be zero for path sizes that worked, so the bug was invisible until clients started probing attributes whose path layout exposed it.

## End-to-end validation

| Client | Probe | Before this PR | After this PR |
|---|---|---|---|
| pycomm3 `LogixDriver("addr")` | `ListIdentity` over TCP | timeout in `_list_identity()` | `plc.info` populates with VendorID, ProductCode, etc. |
| pycomm3 `LogixDriver("addr").open()` | Identity GAA after Register | timeout | open() succeeds |
| FT Linx shortcut bind | Identity GAA + attribute probes | "no path to Primary device" | shortcut binds, peer classified as Logix |
| Real CompactLogix Get_Attribute_Single | bad attribute number | no response | `0x14` Attribute Not Supported |

`go test -race ./...` and `go vet ./...` are clean on the merged branch.

## What's in this PR

Four commits:

- `feat(server): implement CIP Identity Object Get_Attributes_All` — adds `unconnectedGetAttributeAll` for the CIP path. Class `0x01` Instance `1` only; other class/instance combinations return `CIPStatus_PathDestinationUnknown`.
- `feat(server): respond to EtherNet/IP List Identity (command 0x63) over TCP` — adds the encap-level handler, builds the CPF Identity Item with the correct big-endian sockaddr_in layout for `sin_family / sin_port / sin_addr`.
- `fix(server): emit FO API echo + CIP error replies + Class 0x64 stub` — switches the unconnected dispatcher from silent drops to formal error replies, fills in the `OT_API / TO_API` echo on Forward Open success replies, and adds a minimal Class 0x64 Program Object response so pycomm3's `get_plc_name` probe completes.
- `feat(server): handle Get_Attributes_All on connected sessions + connected error replies` — mirrors the unconnected dispatch on the connected path so the same Class 0x01 / 0x64 probes work after a Forward Open. Adds a `sendUnitDataErrorReply` helper.

## Out of scope

- UDP-broadcast List Identity on port 44818. The TCP path is what pycomm3 and the current FT Linx flow use; the broadcast path needs a separate listener that we'd rather track in its own PR if it turns out to be needed in practice.
- Symbol Listing (Class `0x6B`) — comes in the follow-up PR alongside the Class 0xC8 SCADA bridge and the array element access work.
- FactoryTalk View Studio tag browse — that relies on a Rockwell-proprietary service (`0x4B` on Class `0x64`) that is out of scope for this library to implement.

## How to verify

```bash
go test -count=1 -race .
go vet ./...

# Smoke test without a PLC:
cd examples/Server_Class3 && go run . &
pip install pycomm3
python -c "from pycomm3 import LogixDriver; \
  c=LogixDriver('127.0.0.1'); c.open(); print(c.info); c.close()"
```

For FactoryTalk Linx: create a generic EDS shortcut pointing at the gologix host with path `1, 0`, then `Apply + Verify` — the shortcut should bind cleanly with the device icon turning green in the tree.

Co-authored-by: Diego Serrano <dieser88@users.noreply.github.com>
